### PR TITLE
Real-time address verification + Census geocoder

### DIFF
--- a/packages/app/src/app/(app)/admin/editor/page.tsx
+++ b/packages/app/src/app/(app)/admin/editor/page.tsx
@@ -41,6 +41,7 @@ import { Card } from "@/components/Card";
 import { Button } from "@/components/Button";
 import { RelationPicker, type RelationOption } from "@/components/admin/RelationPicker";
 import { EntityDataSourcesPanel } from "@/components/admin/EntityDataSourcesPanel";
+import { AddressVerify, type VerifiedCoords } from "@/components/admin/AddressVerify";
 
 const PAGE_SIZE = 50;
 
@@ -355,7 +356,7 @@ function RunsSection({
 
   async function handleCreateVenue(name: string) {
     const result = await executeVenueCreate({
-      input: { name, address: "TBD", city: "NYC", state: "NY", latitude: 40.7128, longitude: -74.006 },
+      input: { name },
     });
     if (result.data?.venueFindOrCreate?.venue?.id) {
       setNewVenueIds((prev) => [...prev, result.data.venueFindOrCreate.venue.id]);
@@ -714,6 +715,12 @@ function VenuesEditor() {
   const [search, setSearch] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
   const [fields, setFields] = useState<Record<string, string>>({});
+  // Verified map coordinates for the venue being edited; sent on save so the
+  // pin is placed immediately instead of round-tripping the async geocoder.
+  const [verifiedCoords, setVerifiedCoords] = useState<VerifiedCoords | null>(null);
+  // Address fields as loaded, to detect when the admin has changed the address
+  // (and therefore must re-verify before saving).
+  const [loadedAddr, setLoadedAddr] = useState("");
   const [message, setMessage] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<any | null>(null);
   const [mergeSource, setMergeSource] = useState<any | null>(null);
@@ -761,7 +768,7 @@ function VenuesEditor() {
     if (!newName.trim()) return;
     setMessage(null);
     const result = await executeCreate({
-      input: { name: newName.trim(), address: "TBD", city: "NYC", state: "NY", latitude: 40.7128, longitude: -74.006 },
+      input: { name: newName.trim() },
     });
     if (result.data?.venueFindOrCreate?.error) {
       setMessage(result.data.venueFindOrCreate.error);
@@ -777,6 +784,16 @@ function VenuesEditor() {
 
   function startEdit(venue: any) {
     setEditingId(venue.id);
+    setVerifiedCoords(
+      venue.coordinates?.lat != null && venue.coordinates?.lng != null
+        ? { lat: venue.coordinates.lat, lng: venue.coordinates.lng }
+        : null
+    );
+    setLoadedAddr(
+      [venue.address, venue.city, venue.state, venue.zipCode]
+        .map((s: string) => (s || "").trim())
+        .join("|")
+    );
     setFields({
       name: venue.name || "",
       description: venue.description || "",
@@ -798,6 +815,20 @@ function VenuesEditor() {
   async function handleSave() {
     if (!editingId) return;
     setMessage(null);
+
+    // Require verification when the address has been changed. A changed address
+    // with no verified pin is exactly how "TBD / wrong-state" garbage used to
+    // get saved — block it at the source.
+    const currentAddr = [fields.address, fields.city, fields.state, fields.zipCode]
+      .map((s) => (s || "").trim())
+      .join("|");
+    const addressChanged = currentAddr !== loadedAddr;
+    const hasAnyAddress = currentAddr.replace(/\|/g, "").length > 0;
+    if (addressChanged && hasAnyAddress && !verifiedCoords) {
+      setMessage("Verify the address before saving (click “Verify address”).");
+      return;
+    }
+
     const { permanentlyClosed, closedDate, ...rest } = fields;
     const result = await executeUpdate({
       input: {
@@ -805,6 +836,9 @@ function VenuesEditor() {
         ...rest,
         permanentlyClosed: permanentlyClosed === "true",
         closedDate: closedDate || null,
+        ...(verifiedCoords
+          ? { latitude: verifiedCoords.lat, longitude: verifiedCoords.lng }
+          : {}),
       },
     });
     if (result.data?.venueUpdate?.error) {
@@ -895,6 +929,16 @@ function VenuesEditor() {
                     <FieldEditor label="City" value={fields.city} onChange={(v) => setFields((f) => ({ ...f, city: v }))} />
                     <FieldEditor label="State" value={fields.state} onChange={(v) => setFields((f) => ({ ...f, state: v }))} />
                     <FieldEditor label="ZIP Code" value={fields.zipCode} onChange={(v) => setFields((f) => ({ ...f, zipCode: v }))} />
+                    <div className="sm:col-span-2">
+                      <AddressVerify
+                        address={fields.address || ""}
+                        city={fields.city || ""}
+                        state={fields.state || ""}
+                        zipCode={fields.zipCode || ""}
+                        initialCoords={verifiedCoords}
+                        onResolved={setVerifiedCoords}
+                      />
+                    </div>
                     <FieldEditor label="Capacity" value={fields.capacity} onChange={(v) => setFields((f) => ({ ...f, capacity: v }))} type="number" />
                     <FieldEditor label="Website" value={fields.website} onChange={(v) => setFields((f) => ({ ...f, website: v }))} />
                     <FieldEditor label="Phone" value={fields.phone} onChange={(v) => setFields((f) => ({ ...f, phone: v }))} />
@@ -1270,7 +1314,7 @@ function RunsEditor() {
 
   async function handleCreateVenue(name: string) {
     const result = await executeVenueCreate({
-      input: { name, address: "TBD", city: "NYC", state: "NY", latitude: 40.7128, longitude: -74.006 },
+      input: { name },
     });
     if (result.data?.venueFindOrCreate?.venue?.id) {
       const newId = result.data.venueFindOrCreate.venue.id;
@@ -1606,7 +1650,7 @@ function PerformancesEditor() {
 
   async function handleCreateVenue(name: string) {
     const result = await executeVenueCreate({
-      input: { name, address: "TBD", city: "NYC", state: "NY", latitude: 40.7128, longitude: -74.006 },
+      input: { name },
     });
     if (result.data?.venueFindOrCreate?.venue?.id) {
       setRelVenueId(result.data.venueFindOrCreate.venue.id);
@@ -1644,7 +1688,7 @@ function PerformancesEditor() {
 
   async function handleCreateVenueForAdd(name: string) {
     const result = await executeVenueCreate({
-      input: { name, address: "TBD", city: "NYC", state: "NY", latitude: 40.7128, longitude: -74.006 },
+      input: { name },
     });
     if (result.data?.venueFindOrCreate?.venue?.id) {
       setAddVenueId(result.data.venueFindOrCreate.venue.id);

--- a/packages/app/src/app/api/geocode/route.ts
+++ b/packages/app/src/app/api/geocode/route.ts
@@ -1,0 +1,68 @@
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+export const maxDuration = 30
+
+import { NextResponse } from 'next/server'
+import { connectToDatabase } from '../../../../../server/src/db/mongoose'
+import { getUser } from '../../../../../server/src/auth/getUser'
+import { geocodeAddress } from '../../../../../server/src/services/geocoding/geocodeAddress'
+
+interface GeocodeBody {
+  address?: string
+  city?: string
+  state?: string
+  zipCode?: string
+}
+
+function composeAddress(b: GeocodeBody): string {
+  return [b.address, b.city, b.state, b.zipCode]
+    .map(p => p?.trim())
+    .filter((p): p is string => !!p)
+    .join(', ')
+}
+
+// Real-time geocode for the admin venue form. Returns coordinates + the
+// canonical matched address, or { found: false } so the form can show inline
+// "address not found" feedback before submit.
+export async function POST(req: Request) {
+  await connectToDatabase()
+
+  const user = await getUser({
+    authorization: req.headers.get('authorization') || undefined
+  })
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const { UserModel } = await import(
+    '../../../../../server/src/entities/user/userModel'
+  )
+  const adminUser = await UserModel.findById(user.id)
+  if (!adminUser?.isAdmin) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+  }
+
+  let body: GeocodeBody
+  try {
+    body = (await req.json()) as GeocodeBody
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const query = composeAddress(body)
+  if (!query) {
+    return NextResponse.json({ found: false, reason: 'Empty address' })
+  }
+
+  const result = await geocodeAddress(query)
+  if (!result) {
+    return NextResponse.json({ found: false, query })
+  }
+
+  return NextResponse.json({
+    found: true,
+    lat: result.lat,
+    lng: result.lng,
+    matchedAddress: result.matchedAddress ?? null,
+    provider: result.provider
+  })
+}

--- a/packages/app/src/components/admin/AddressPreviewMap.tsx
+++ b/packages/app/src/components/admin/AddressPreviewMap.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+
+interface AddressPreviewMapProps {
+  lat: number;
+  lng: number;
+  className?: string;
+}
+
+// Small single-pin preview map for verified venue addresses. Loaded via
+// next/dynamic with ssr:false (leaflet touches window at import time).
+export function AddressPreviewMap({ lat, lng, className = "" }: AddressPreviewMapProps) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<L.Map | null>(null);
+  const markerRef = useRef<L.Marker | null>(null);
+
+  useEffect(() => {
+    if (!mapRef.current || mapInstanceRef.current) return;
+    const map = L.map(mapRef.current, {
+      zoomControl: false,
+      attributionControl: false,
+      dragging: false,
+      scrollWheelZoom: false,
+      doubleClickZoom: false,
+    }).setView([lat, lng], 15);
+    L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+      maxZoom: 19,
+    }).addTo(map);
+    markerRef.current = L.marker([lat, lng]).addTo(map);
+    mapInstanceRef.current = map;
+
+    return () => {
+      map.remove();
+      mapInstanceRef.current = null;
+      markerRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Recenter/move the pin when a new verification comes back.
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+    map.setView([lat, lng], 15);
+    if (markerRef.current) markerRef.current.setLatLng([lat, lng]);
+  }, [lat, lng]);
+
+  return <div ref={mapRef} className={className} />;
+}

--- a/packages/app/src/components/admin/AddressVerify.tsx
+++ b/packages/app/src/components/admin/AddressVerify.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+import { getStoredAccessToken } from "@/lib/auth/token";
+
+const AddressPreviewMap = dynamic(
+  () => import("./AddressPreviewMap").then((m) => m.AddressPreviewMap),
+  { ssr: false, loading: () => <div className="h-40 w-full bg-curtn-deep" /> }
+);
+
+export interface VerifiedCoords {
+  lat: number;
+  lng: number;
+}
+
+interface AddressVerifyProps {
+  address: string;
+  city: string;
+  state: string;
+  zipCode: string;
+  // Initial coords from the saved venue (so an already-placed pin shows on open).
+  initialCoords?: VerifiedCoords | null;
+  // Fires with coords when an address verifies, or null when verification is
+  // cleared / fails. The parent stores these and sends them on save.
+  onResolved: (coords: VerifiedCoords | null) => void;
+}
+
+type Status = "idle" | "loading" | "found" | "notfound" | "error";
+
+function composeQuery(p: { address: string; city: string; state: string; zipCode: string }): string {
+  return [p.address, p.city, p.state, p.zipCode]
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .join(", ");
+}
+
+export function AddressVerify({
+  address,
+  city,
+  state,
+  zipCode,
+  initialCoords,
+  onResolved,
+}: AddressVerifyProps) {
+  const [status, setStatus] = useState<Status>(initialCoords ? "found" : "idle");
+  const [coords, setCoords] = useState<VerifiedCoords | null>(initialCoords ?? null);
+  const [matchedAddress, setMatchedAddress] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  // The address string the current pin was verified against. If the form's
+  // address drifts from this, the pin is stale and must be re-verified.
+  const [verifiedQuery, setVerifiedQuery] = useState<string | null>(
+    initialCoords ? composeQuery({ address, city, state, zipCode }) : null
+  );
+
+  const currentQuery = composeQuery({ address, city, state, zipCode });
+  const isStale = status === "found" && verifiedQuery !== null && currentQuery !== verifiedQuery;
+
+  // When the address drifts from what was verified, drop the coords so the
+  // parent won't save a pin that no longer matches the typed address.
+  useEffect(() => {
+    if (isStale) onResolved(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isStale]);
+
+  async function verify() {
+    if (!currentQuery) {
+      setStatus("notfound");
+      setMessage("Enter an address to verify.");
+      onResolved(null);
+      return;
+    }
+    setStatus("loading");
+    setMessage(null);
+    try {
+      const token = getStoredAccessToken();
+      const res = await fetch("/api/geocode", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ address, city, state, zipCode }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setStatus("error");
+        setMessage(data.error || "Verification failed.");
+        onResolved(null);
+        return;
+      }
+      if (data.found) {
+        const c = { lat: data.lat, lng: data.lng };
+        setCoords(c);
+        setMatchedAddress(data.matchedAddress ?? null);
+        setVerifiedQuery(currentQuery);
+        setStatus("found");
+        onResolved(c);
+      } else {
+        setStatus("notfound");
+        setMatchedAddress(null);
+        setMessage("Couldn't find that address — check the street, city, and state.");
+        onResolved(null);
+      }
+    } catch {
+      setStatus("error");
+      setMessage("Network error — try again.");
+      onResolved(null);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={verify}
+          disabled={status === "loading"}
+          className="dog-ear-sm bg-curtn-coral px-3 py-1.5 text-xs font-medium uppercase tracking-wide text-curtn-deep transition-colors hover:bg-curtn-red disabled:opacity-50"
+        >
+          {status === "loading" ? "Verifying…" : "Verify address"}
+        </button>
+        {status === "found" && !isStale && (
+          <span className="text-xs text-curtn-acid">✓ Located on map</span>
+        )}
+        {isStale && (
+          <span className="text-xs text-curtn-muted">Address changed — verify again</span>
+        )}
+        {(status === "notfound" || status === "error") && (
+          <span className="text-xs text-curtn-red">✗ {message}</span>
+        )}
+      </div>
+
+      {matchedAddress && status === "found" && !isStale && (
+        <p className="text-xs text-curtn-muted">Matched: {matchedAddress}</p>
+      )}
+
+      {status === "found" && !isStale && coords && (
+        <div className="overflow-hidden border border-curtn-dark">
+          <AddressPreviewMap lat={coords.lat} lng={coords.lng} className="h-40 w-full" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/lib/graphql/admin.ts
+++ b/packages/app/src/lib/graphql/admin.ts
@@ -435,6 +435,7 @@ export const ADMIN_VENUE_LIST_QUERY = gql`
           permanentlyClosed
           closedDate
           createdAt
+          coordinates { lat lng }
         }
       }
       pageInfo {
@@ -620,6 +621,7 @@ export const VENUE_UPDATE_MUTATION = gql`
         imageUrl
         permanentlyClosed
         closedDate
+        coordinates { lat lng }
       }
       error
     }

--- a/packages/server/src/entities/venue/mutations/venueFindOrCreate.ts
+++ b/packages/server/src/entities/venue/mutations/venueFindOrCreate.ts
@@ -18,24 +18,24 @@ export const venueFindOrCreate = mutationWithClientMutationId({
       description: 'Venue name (case-insensitive match)'
     },
     address: {
-      type: new GraphQLNonNull(GraphQLString),
-      description: 'Street address'
+      type: GraphQLString,
+      description: 'Street address (optional — omit for a name-only stub to be verified later)'
     },
     city: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       description: 'City (NYC, Minneapolis, LA)'
     },
     state: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       description: 'State (NY, MN, CA)'
     },
     latitude: {
-      type: new GraphQLNonNull(GraphQLFloat),
-      description: 'Latitude coordinate'
+      type: GraphQLFloat,
+      description: 'Latitude coordinate (set with longitude to place the pin)'
     },
     longitude: {
-      type: new GraphQLNonNull(GraphQLFloat),
-      description: 'Longitude coordinate'
+      type: GraphQLFloat,
+      description: 'Longitude coordinate (set with latitude to place the pin)'
     },
     venueType: {
       type: GraphQLString,
@@ -78,23 +78,30 @@ export const venueFindOrCreate = mutationWithClientMutationId({
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/^-+|-+$/g, '')
 
-      const trimmedAddress = input.address.trim()
-
-      const venue = await new VenueModel({
+      // Build only the fields actually supplied. A name-only stub gets no
+      // address and no location — avoiding the old "TBD / NYC default pin"
+      // garbage. Coordinates are written only when both are present, and the
+      // address is verified at edit time.
+      const venueDoc: Record<string, any> = {
         name,
         slug,
-        address: trimmedAddress,
-        city: input.city,
-        state: input.state,
-        location: {
-          type: 'Point',
-          coordinates: [input.longitude, input.latitude]
-        },
         venueType: input.venueType || 'theater',
         website: input.website,
         verificationStatus: 'community',
         submittedBy: ctx.user.id
-      }).save()
+      }
+      const trimmedAddress = input.address?.trim()
+      if (trimmedAddress) venueDoc.address = trimmedAddress
+      if (input.city) venueDoc.city = input.city
+      if (input.state) venueDoc.state = input.state
+      if (typeof input.latitude === 'number' && typeof input.longitude === 'number') {
+        venueDoc.location = {
+          type: 'Point',
+          coordinates: [input.longitude, input.latitude]
+        }
+      }
+
+      const venue = await new VenueModel(venueDoc).save()
 
       return { venue, created: true }
     } catch (err) {

--- a/packages/server/src/entities/venue/mutations/venueUpdate.ts
+++ b/packages/server/src/entities/venue/mutations/venueUpdate.ts
@@ -1,4 +1,4 @@
-import { GraphQLBoolean, GraphQLNonNull, GraphQLString } from 'graphql'
+import { GraphQLBoolean, GraphQLFloat, GraphQLNonNull, GraphQLString } from 'graphql'
 import { mutationWithClientMutationId } from 'graphql-relay'
 import { venueType } from '../venueTypes'
 import { VenueModel } from '../venueModel'
@@ -45,6 +45,14 @@ export const venueUpdate = mutationWithClientMutationId({
     zipCode: {
       type: GraphQLString,
       description: 'ZIP/postal code'
+    },
+    latitude: {
+      type: GraphQLFloat,
+      description: 'Latitude from address verification. Set with longitude to place the map pin directly (skips the async geocoding queue).'
+    },
+    longitude: {
+      type: GraphQLFloat,
+      description: 'Longitude from address verification. Set with latitude to place the map pin directly.'
     },
     capacity: {
       type: GraphQLString,
@@ -157,7 +165,10 @@ export const venueUpdate = mutationWithClientMutationId({
       if (input.permanentlyClosed !== undefined) updates.permanentlyClosed = input.permanentlyClosed
       if (input.closedDate !== undefined) updates.closedDate = input.closedDate ? new Date(input.closedDate) : null
 
-      if (Object.keys(updates).length === 0) {
+      const hasCoords =
+        typeof input.latitude === 'number' && typeof input.longitude === 'number'
+
+      if (Object.keys(updates).length === 0 && !hasCoords) {
         return { venue }
       }
 
@@ -172,6 +183,17 @@ export const venueUpdate = mutationWithClientMutationId({
           isCommunityReview: !!decision.isCommunityReview,
         })
         return { queued: true, proposalId: result.proposalId, venue, isCommunityReview: !!decision.isCommunityReview }
+      }
+
+      // Verified coordinates place the pin directly. Applied only on the
+      // direct-publish path (derived geo isn't community-reviewable, so it
+      // stays out of the proposal diff above) and after it, so it doesn't
+      // need to round-trip through the async geocoding queue.
+      if (hasCoords) {
+        updates.location = {
+          type: 'Point',
+          coordinates: [input.longitude, input.latitude] // GeoJSON: [lng, lat]
+        }
       }
 
       const oldDoc = venue.toObject()

--- a/packages/server/src/scripts/diagGeocoding.ts
+++ b/packages/server/src/scripts/diagGeocoding.ts
@@ -1,0 +1,63 @@
+import '../config/env'
+import mongoose from 'mongoose'
+import { VenueModel } from '../entities/venue/venueModel'
+import { GeocodingJobModel } from '../entities/geocodingJob/geocodingJobModel'
+
+async function main() {
+  const mongoUrl = process.env.MONGODB_URL
+  if (!mongoUrl) throw new Error('MONGODB_URL not set')
+  await mongoose.connect(mongoUrl)
+
+  // 1. Queue-wide stats
+  const byStatus = await GeocodingJobModel.aggregate([
+    { $group: { _id: '$status', count: { $sum: 1 } } }
+  ])
+  console.log('\n=== Geocoding job counts by status ===')
+  console.log(byStatus)
+
+  // Stuck 'processing' jobs (no reaper exists — these are orphaned)
+  const stuck = await GeocodingJobModel.find({ status: 'processing' })
+    .select('venueId attemptCount lastAttemptAt lastError').lean()
+  console.log(`\n=== Stuck 'processing' jobs: ${stuck.length} ===`)
+  stuck.slice(0, 20).forEach(j => console.log(`  venue=${j.venueId} attempts=${j.attemptCount} lastAttempt=${(j as any).lastAttemptAt} err=${j.lastError}`))
+
+  // Failed jobs
+  const failed = await GeocodingJobModel.find({ status: 'failed' })
+    .select('venueId attemptCount lastError').lean()
+  console.log(`\n=== Failed jobs: ${failed.length} ===`)
+  failed.slice(0, 30).forEach(j => console.log(`  venue=${j.venueId} attempts=${j.attemptCount} err=${j.lastError}`))
+
+  // Pending that are due now vs scheduled later
+  const now = new Date()
+  const dueNow = await GeocodingJobModel.countDocuments({ status: 'pending', nextAttemptAt: { $lte: now } })
+  const scheduled = await GeocodingJobModel.countDocuments({ status: 'pending', nextAttemptAt: { $gt: now } })
+  console.log(`\n=== Pending: dueNow=${dueNow} scheduledLater=${scheduled} ===`)
+
+  // 2. Long Beach Playhouse specifically
+  console.log('\n=== Long Beach Playhouse ===')
+  const venues = await VenueModel.find({ name: /long beach/i })
+    .select('name address city state zipCode location updatedAt').lean()
+  for (const v of venues) {
+    console.log(`\nvenue ${v._id}: "${v.name}"`)
+    console.log(`  address="${v.address ?? ''}" city="${v.city ?? ''}" state="${v.state ?? ''}" zip="${v.zipCode ?? ''}"`)
+    console.log(`  location=${JSON.stringify(v.location)}`)
+    console.log(`  updatedAt=${(v as any).updatedAt}`)
+    const jobs = await GeocodingJobModel.find({ venueId: v._id })
+      .select('status attemptCount nextAttemptAt lastError addressSnapshot completedAt').lean()
+    if (!jobs.length) {
+      console.log(`  >>> NO geocoding job exists for this venue <<<`)
+    }
+    jobs.forEach(j => console.log(`  job ${j._id}: status=${j.status} attempts=${j.attemptCount} next=${(j as any).nextAttemptAt} snapshot=${JSON.stringify(j.addressSnapshot)} err=${j.lastError}`))
+  }
+
+  // 3. Venues with a street address but no location (the real backlog)
+  const missingLoc = await VenueModel.countDocuments({
+    address: { $exists: true, $nin: ['', null] },
+    location: { $exists: false }
+  })
+  console.log(`\n=== Venues with street address but NO location field: ${missingLoc} ===`)
+
+  await mongoose.disconnect()
+}
+
+main().catch(err => { console.error(err); process.exit(1) })

--- a/packages/server/src/services/geocoding/census.ts
+++ b/packages/server/src/services/geocoding/census.ts
@@ -1,0 +1,56 @@
+import axios from 'axios'
+import { GeocodeResult } from './nominatim'
+
+// US Census Bureau geocoder. Free, no API key, no meaningful rate limit, and
+// results are storable. US-only and expects a parseable street address
+// (number + street); it will not resolve a bare venue name or a city alone.
+// For anything outside that envelope we fall back to Nominatim.
+const CENSUS_ENDPOINT =
+  'https://geocoding.geo.census.gov/geocoder/locations/onelineaddress'
+const BENCHMARK = 'Public_AR_Current'
+const REQUEST_TIMEOUT_MS = 15000
+
+export interface CensusGeocodeResult extends GeocodeResult {
+  matchedAddress: string
+}
+
+interface CensusMatch {
+  matchedAddress?: string
+  coordinates?: { x?: number; y?: number } // x = longitude, y = latitude
+}
+
+interface CensusResponse {
+  result?: { addressMatches?: CensusMatch[] }
+}
+
+export async function geocodeViaCensus(
+  query: string
+): Promise<CensusGeocodeResult | null> {
+  if (!query.trim()) return null
+
+  try {
+    const response = await axios.get<CensusResponse>(CENSUS_ENDPOINT, {
+      params: {
+        address: query,
+        benchmark: BENCHMARK,
+        format: 'json'
+      },
+      timeout: REQUEST_TIMEOUT_MS
+    })
+
+    const match = response.data?.result?.addressMatches?.[0]
+    const lng = match?.coordinates?.x
+    const lat = match?.coordinates?.y
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
+
+    return {
+      lat: lat as number,
+      lng: lng as number,
+      matchedAddress: match?.matchedAddress ?? query
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.warn(`[geocoding] Census request failed for "${query}": ${message}`)
+    return null
+  }
+}

--- a/packages/server/src/services/geocoding/geocodeAddress.ts
+++ b/packages/server/src/services/geocoding/geocodeAddress.ts
@@ -1,0 +1,44 @@
+import { geocodeViaCensus } from './census'
+import { geocodeViaNominatim } from './nominatim'
+
+export interface ResolvedGeocode {
+  lat: number
+  lng: number
+  matchedAddress?: string
+  provider: 'census' | 'nominatim'
+}
+
+// Geocode a US address through the provider chain:
+//   1. US Census  — free, unlimited, storable, authoritative for US street
+//      addresses. Try first.
+//   2. Nominatim  — fuzzier (catches odd formats / venue-ish strings Census
+//      rejects), but rate-limited to ~1 req/sec. Only hit when Census misses.
+//
+// `onNominatimFallback` lets the caller throttle ONLY when we actually reach
+// Nominatim (the queue worker needs the 1 req/sec pause; the interactive
+// endpoint doesn't need to wait at all).
+export async function geocodeAddress(
+  query: string,
+  opts: { onNominatimFallback?: () => Promise<void> } = {}
+): Promise<ResolvedGeocode | null> {
+  if (!query.trim()) return null
+
+  const census = await geocodeViaCensus(query)
+  if (census) {
+    return {
+      lat: census.lat,
+      lng: census.lng,
+      matchedAddress: census.matchedAddress,
+      provider: 'census'
+    }
+  }
+
+  if (opts.onNominatimFallback) await opts.onNominatimFallback()
+
+  const osm = await geocodeViaNominatim(query)
+  if (osm) {
+    return { lat: osm.lat, lng: osm.lng, provider: 'nominatim' }
+  }
+
+  return null
+}

--- a/packages/server/src/services/geocoding/processGeocodingJobs.ts
+++ b/packages/server/src/services/geocoding/processGeocodingJobs.ts
@@ -1,11 +1,16 @@
 import { GeocodingJobModel, IGeocodingJob } from '../../entities/geocodingJob/geocodingJobModel'
 import { VenueModel } from '../../entities/venue/venueModel'
-import { geocodeViaNominatim } from './nominatim'
+import { geocodeAddress } from './geocodeAddress'
 
 const THROTTLE_MS = 1100           // Nominatim: max 1 req/sec; 1.1s for headroom
 const MAX_ATTEMPTS = 5
 const MAX_BATCH = 10
 const DEFAULT_TIME_BUDGET_MS = 8000 // stay under Vercel Hobby 10s function limit
+// A job claimed (status -> 'processing') but never resolved — because the
+// function timed out or crashed mid-tick — would otherwise be stranded forever,
+// since the worker only ever queries for 'pending'. Reclaim anything stuck in
+// 'processing' past this age back into the queue.
+const STUCK_PROCESSING_MS = 5 * 60_000 // 5 min
 
 // Exponential backoff schedule (in ms). Index = attemptCount after failure.
 const BACKOFF_SCHEDULE_MS = [
@@ -36,6 +41,7 @@ export interface ProcessResult {
   succeeded: number
   failed: number
   retryScheduled: number
+  reaped: number
   timedOut: boolean
 }
 
@@ -50,8 +56,19 @@ export async function processGeocodingJobs(
     succeeded: 0,
     failed: 0,
     retryScheduled: 0,
+    reaped: 0,
     timedOut: false
   }
+
+  // Reaper: reclaim jobs stranded in 'processing' by a crashed/timed-out tick.
+  const reap = await GeocodingJobModel.updateMany(
+    {
+      status: 'processing',
+      lastAttemptAt: { $lte: new Date(Date.now() - STUCK_PROCESSING_MS) }
+    },
+    { $set: { status: 'pending', nextAttemptAt: new Date() } }
+  )
+  result.reaped = reap.modifiedCount ?? 0
 
   for (let i = 0; i < MAX_BATCH; i++) {
     if (Date.now() >= deadline) {
@@ -80,8 +97,16 @@ export async function processGeocodingJobs(
 
     const query = composeAddress(job.addressSnapshot)
     let geocodeResult: { lat: number; lng: number } | null = null
+    let usedNominatim = false
     if (query) {
-      geocodeResult = await geocodeViaNominatim(query)
+      // Census first (free/unlimited). Only pause for the 1 req/sec Nominatim
+      // limit if we actually fall through to it.
+      geocodeResult = await geocodeAddress(query, {
+        onNominatimFallback: async () => {
+          usedNominatim = true
+          await sleep(THROTTLE_MS)
+        }
+      })
     }
 
     if (geocodeResult) {
@@ -137,7 +162,10 @@ export async function processGeocodingJobs(
       result.timedOut = true
       break
     }
-    await sleep(THROTTLE_MS)
+    // Census carries no rate limit, so only throttle between iterations when a
+    // job actually reached Nominatim (the fallback already slept before its
+    // own call; this guards the *next* iteration).
+    if (usedNominatim) await sleep(THROTTLE_MS)
   }
 
   return result


### PR DESCRIPTION
## What
Replaces the broken Nominatim-only async geocoding with a **Census-first** chain and adds **verify-at-input** address entry to the admin venue form (macOS-Calendar-style: instant pin or inline "not found").

## Why
The geocoding cron was silently failing on prod (`test` DB): jobs got stranded in `processing` by Vercel's 10s timeout and were never reclaimed, so venues like Long Beach Playhouse sat on the Manhattan default pin for a month. Nominatim also couldn't resolve many valid US addresses.

## Changes
**Geocoder**
- `geocodeViaCensus` — US Census, free, no key, no rate limit, storable
- `geocodeAddress` chain — Census first, Nominatim fallback
- `processGeocodingJobs` — uses the chain, throttles only on Nominatim, and **reaps stuck `processing` jobs** (the freeze bug)

**Real-time entry**
- `POST /api/geocode` (admin-gated) → coords + matched address, or `{found:false}`
- `AddressVerify` + `AddressPreviewMap` — Verify button, Leaflet pin preview, re-verify-on-edit
- `venueUpdate` accepts `latitude/longitude`, writes the pin directly (skips the queue for manual entry)

**Garbage-proofing**
- `venueFindOrCreate` no longer requires address/coords → name-only stubs, no Manhattan default pin
- Quick-create sites drop the `TBD / NYC / 40.7128,-74.006` defaults
- Editor blocks save when the address changed but wasn't verified

## Verified
- Long Beach Playhouse: Manhattan default → correct LA coords via Census
- Stuck-in-`processing`: 8 → 0
- `tsc` clean both packages; 20 venue/proposal/audit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)