### PR TITLE
fix: address-preview map z-index below header

### DIFF
--- a/packages/app/src/components/admin/AddressVerify.tsx
+++ b/packages/app/src/components/admin/AddressVerify.tsx
@@ -136,7 +136,7 @@ export function AddressVerify({
       )}
 
       {status === "found" && !isStale && coords && (
-        <div className="overflow-hidden border border-curtn-dark">
+        <div className="relative z-0 isolate overflow-hidden border border-curtn-dark">
           <AddressPreviewMap lat={coords.lat} lng={coords.lng} className="h-40 w-full" />
         </div>
       )}


### PR DESCRIPTION
Leaflet's high z-index panes/controls were painting over the fixed header on scroll. Wrap the preview in a contained stacking context (relative z-0 isolate). Affects both editors (shared AddressVerify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)