### PR TITLE
fix: map blank when zoomed out (bbox clamp + world-skip)

### DIFF
--- a/packages/server/src/entities/performance/queries/queries.ts
+++ b/packages/server/src/entities/performance/queries/queries.ts
@@ -5,6 +5,7 @@ import { RunModel } from '../../run/runModel'
 import { VenueModel } from '../../venue/venueModel'
 import { connectionArgs, connectionFromArray, fromGlobalId } from 'graphql-relay'
 import { applyCursorToQuery, buildConnection } from '../../../graphql/cursorPagination'
+import { buildBboxLocationFilter } from '../../../services/geo/bboxFilter'
 
 export const singlePerformance: GraphQLFieldConfig<any, any, { id: string }> = {
   type: performanceType,
@@ -112,20 +113,16 @@ export const performanceList: GraphQLFieldConfig<any, any, any> = {
       if (startDate) baseFilter.date = { ...baseFilter.date, $gte: new Date(startDate) }
       if (endDate) baseFilter.date = { ...baseFilter.date, $lt: new Date(endDate) }
 
-      // Bbox filter — only when all four corners provided and no text search active
+      // Bbox filter — only when all four corners provided and no text search active.
+      // A world-ish / wrapped box yields null → no venue filter, so far-zoom
+      // returns all performances (capped) to cluster instead of a blank map.
       const hasBbox = swLat != null && swLng != null && neLat != null && neLng != null
       if (hasBbox && !search) {
-        const venueIds = await VenueModel.find({
-          location: {
-            $geoWithin: {
-              $geometry: {
-                type: 'Polygon',
-                coordinates: [[[swLng, swLat], [neLng, swLat], [neLng, neLat], [swLng, neLat], [swLng, swLat]]]
-              }
-            }
-          }
-        }).distinct('_id')
-        baseFilter.venueId = { $in: venueIds }
+        const locationFilter = buildBboxLocationFilter(swLat, swLng, neLat, neLng)
+        if (locationFilter) {
+          const venueIds = await VenueModel.find({ location: locationFilter }).distinct('_id')
+          baseFilter.venueId = { $in: venueIds }
+        }
       }
 
       if (search) {

--- a/packages/server/src/entities/venue/queries/queries.ts
+++ b/packages/server/src/entities/venue/queries/queries.ts
@@ -3,6 +3,7 @@ import { VenueConnection, venueType } from '../venueTypes'
 import { VenueModel } from '../venueModel'
 import { connectionArgs, connectionFromArray, fromGlobalId } from 'graphql-relay'
 import { applyCursorToQuery, buildConnection, connectionFromArrayLean } from '../../../graphql/cursorPagination'
+import { buildBboxLocationFilter } from '../../../services/geo/bboxFilter'
 
 // Get a single venue by ID
 export const singleVenue: GraphQLFieldConfig<any, any, { id: string }> = {
@@ -97,16 +98,12 @@ export const venueList: GraphQLFieldConfig<any, any, VenueListArgs> = {
 
     // Bbox filter — only when all four corners are provided and no text search
     // (MongoDB can't combine a text index and 2dsphere index in one query)
+    // A world-ish / wrapped box yields null → no geo filter, so far-zoom returns
+    // all venues (capped) to cluster instead of a blank map.
     const hasBbox = swLat != null && swLng != null && neLat != null && neLng != null
     if (hasBbox && !search) {
-      filter.location = {
-        $geoWithin: {
-          $geometry: {
-            type: 'Polygon',
-            coordinates: [[[swLng!, swLat!], [neLng!, swLat!], [neLng!, neLat!], [swLng!, neLat!], [swLng!, swLat!]]]
-          }
-        }
-      }
+      const locationFilter = buildBboxLocationFilter(swLat!, swLng!, neLat!, neLng!)
+      if (locationFilter) filter.location = locationFilter
     }
 
     const empty = { edges: [], pageInfo: { hasNextPage: false, hasPreviousPage: false, startCursor: null, endCursor: null } }

--- a/packages/server/src/services/geo/bboxFilter.ts
+++ b/packages/server/src/services/geo/bboxFilter.ts
@@ -1,0 +1,42 @@
+// Build the MongoDB `location` filter for a viewport bounding box.
+//
+// Returns a `$geoWithin` GeoJSON polygon clamped to valid lng/lat ranges, OR
+// null when the box is effectively global (zoomed far out) or wrapped across
+// the antimeridian. Null tells the caller to skip geo filtering and return
+// everything (capped) — at world zoom you want all pins to cluster, not an
+// empty map.
+//
+// The previous code fed raw, 50%-padded bounds straight into `$geometry`:
+//   - coordinates beyond ±180 / ±90 made MongoDB throw → caught → empty result
+//     → blank map (the reported bug);
+//   - polygons larger than a hemisphere had their winding inverted by the
+//     spherical engine → also empty.
+// Clamping fixes the first; the world-skip fixes the second.
+export function buildBboxLocationFilter(
+  swLat: number,
+  swLng: number,
+  neLat: number,
+  neLng: number
+): Record<string, any> | null {
+  const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v))
+  let s = clamp(swLat, -90, 90)
+  let n = clamp(neLat, -90, 90)
+  const w = clamp(swLng, -180, 180)
+  const e = clamp(neLng, -180, 180)
+  if (s > n) [s, n] = [n, s]
+
+  // Antimeridian wrap (w >= e after clamping) or a near-hemispheric extent:
+  // the polygon stops being meaningful / safe, so skip it and show all.
+  const lngSpan = e - w
+  const latSpan = n - s
+  if (w >= e || lngSpan >= 180 || latSpan >= 90) return null
+
+  return {
+    $geoWithin: {
+      $geometry: {
+        type: 'Polygon',
+        coordinates: [[[w, s], [e, s], [e, n], [w, n], [w, s]]]
+      }
+    }
+  }
+}


### PR DESCRIPTION
At far zoom, the 50%-padded viewport bounds pushed the `$geoWithin` polygon out of valid lng/lat range (MongoDB throws → empty → blank) and past a hemisphere (winding inverts → empty). New `buildBboxLocationFilter` clamps the box and returns null for world-ish/wrapped bounds so the query returns all pins to cluster. Applied to performance + venue map queries. Helper logic unit-verified (6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)