### PR TITLE
fix: loosen map cluster radius (40 → 80)

### DIFF
--- a/packages/app/src/components/map/PerformanceMap.tsx
+++ b/packages/app/src/components/map/PerformanceMap.tsx
@@ -161,7 +161,10 @@ export function PerformanceMap({ performances, className = "", onBoundsChange }:
     }
 
     const cluster = L.markerClusterGroup({
-      maxClusterRadius: 40,
+      // 80px (markercluster's default). 40 was too tight: venues only a few
+      // hundred metres apart (e.g. the Lower East Side trio) stayed as separate
+      // dots until zoomed way out instead of merging at city-level zoom.
+      maxClusterRadius: 80,
       spiderfyOnMaxZoom: true,
       showCoverageOnHover: false,
       iconCreateFunction: (c) => {

--- a/packages/app/src/components/map/VenueOnlyMap.tsx
+++ b/packages/app/src/components/map/VenueOnlyMap.tsx
@@ -71,7 +71,8 @@ export function VenueOnlyMap({ venues, className = "", onBoundsChange }: VenueOn
     }
 
     const cluster = L.markerClusterGroup({
-      maxClusterRadius: 40,
+      // 80px default — see PerformanceMap; 40 left close venues unclustered.
+      maxClusterRadius: 80,
       showCoverageOnHover: false,
       iconCreateFunction: (c) => {
         const count = c.getChildCount();


### PR DESCRIPTION
Close-together venues (the LES trio ~400m apart) didn't cluster until zoomed way out because maxClusterRadius was 40px (half default). Bump both map components to 80px so they merge at city-level zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)