### PR TITLE
fix: map pins vanish when zoomed out (lift cap)

### DIFF
--- a/packages/app/src/app/(app)/upcoming/page.tsx
+++ b/packages/app/src/app/(app)/upcoming/page.tsx
@@ -51,7 +51,7 @@ function UpcomingPageContent() {
   // Lightweight venue pins — paused until the map reports its initial bounds
   const [{ data: venueData }] = useQuery({
     query: VENUE_MAP_QUERY,
-    variables: { first: 200, ...mapBounds },
+    variables: { first: 3000, ...mapBounds },
     pause: !mapBounds,
   });
 
@@ -65,7 +65,7 @@ function UpcomingPageContent() {
   // Performance data for map (lightweight — no cast/descriptions)
   const [{ data: mapPerfData, fetching: mapFetching }] = useQuery({
     query: MAP_PERFORMANCES_QUERY,
-    variables: { first: 200, ...mapBounds, ...dateVars },
+    variables: { first: 3000, ...mapBounds, ...dateVars },
     pause: !mapBounds,
   });
 

--- a/packages/server/src/entities/performance/queries/queries.ts
+++ b/packages/server/src/entities/performance/queries/queries.ts
@@ -146,7 +146,12 @@ export const performanceList: GraphQLFieldConfig<any, any, any> = {
         ]
       }
 
-      const geoMaxLimit = hasBbox ? 500 : undefined
+      // Map pins collapse to one marker per venue client-side (and cluster), so
+      // a high ceiling is cheap and avoids high-volume venues (Broadway houses
+      // with ~26 showings each) crowding smaller venues out of the result and
+      // making them vanish when zoomed out. Effectively uncapped for today's
+      // data (~1.3k upcoming) while bounding a pathological payload.
+      const geoMaxLimit = hasBbox ? 3000 : undefined
       const { filter, sort, limit } = applyCursorToQuery(baseFilter, {
         after: (connArgs as any).after,
         first: (connArgs as any).first,

--- a/packages/server/src/entities/venue/queries/queries.ts
+++ b/packages/server/src/entities/venue/queries/queries.ts
@@ -117,7 +117,9 @@ export const venueList: GraphQLFieldConfig<any, any, VenueListArgs> = {
         return connectionFromArrayLean(venues, connectionArgs)
       }
 
-      const geoMaxLimit = hasBbox ? 500 : undefined
+      // High ceiling for the map — venue pins cluster, and there are only a few
+      // hundred venues, so no need to cap tightly (see performance query).
+      const geoMaxLimit = hasBbox ? 3000 : undefined
       const { filter: cursorFilter, sort, limit } = applyCursorToQuery(filter, {
         after: (connectionArgs as any).after,
         first: (connectionArgs as any).first,


### PR DESCRIPTION
Zoomed out, the 200-perf cap was eaten entirely by ~11 high-volume Broadway venues, so smaller venues (the LES trio + ~40 others) returned nothing and disappeared. Pins collapse to ~55 venue markers and cluster, so raise the ceiling to 3000 (effectively uncapped for ~1.3k upcoming perfs). Confirmed via data: large bbox returned only 11 distinct venues; this restores all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)