### PR TITLE
feat: auto-center the map on the user's location

### DIFF
--- a/packages/app/src/components/map/PerformanceMap.tsx
+++ b/packages/app/src/components/map/PerformanceMap.tsx
@@ -5,6 +5,7 @@ import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import "leaflet.markercluster";
 import "leaflet.markercluster/dist/MarkerCluster.css";
+import { centerOnUserLocation } from "./geolocate";
 
 interface Performance {
   id: string;
@@ -147,6 +148,12 @@ export function PerformanceMap({ performances, className = "", onBoundsChange }:
     // Report bounds immediately and on every pan/zoom settle
     reportBounds(map, onBoundsChangeRef.current);
     map.on('moveend', () => reportBounds(map, onBoundsChangeRef.current));
+
+    // Auto-center on the user's location if they grant permission. Skip if
+    // they've already dragged the map by the time the position resolves.
+    let userMoved = false;
+    map.on("dragstart", () => { userMoved = true; });
+    centerOnUserLocation(map, () => userMoved);
 
     return () => { map.remove(); mapInstanceRef.current = null; };
   }, []);

--- a/packages/app/src/components/map/VenueOnlyMap.tsx
+++ b/packages/app/src/components/map/VenueOnlyMap.tsx
@@ -5,6 +5,7 @@ import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import "leaflet.markercluster";
 import "leaflet.markercluster/dist/MarkerCluster.css";
+import { centerOnUserLocation } from "./geolocate";
 
 interface Venue {
   id: string;
@@ -58,6 +59,12 @@ export function VenueOnlyMap({ venues, className = "", onBoundsChange }: VenueOn
 
     reportBounds(map, onBoundsChangeRef.current);
     map.on('moveend', () => reportBounds(map, onBoundsChangeRef.current));
+
+    // Auto-center on the user's location if they grant permission. Skip if
+    // they've already dragged the map by the time the position resolves.
+    let userMoved = false;
+    map.on("dragstart", () => { userMoved = true; });
+    centerOnUserLocation(map, () => userMoved);
 
     return () => { map.remove(); mapInstanceRef.current = null; };
   }, []);

--- a/packages/app/src/components/map/geolocate.ts
+++ b/packages/app/src/components/map/geolocate.ts
@@ -1,0 +1,24 @@
+import L from "leaflet";
+
+// Ask for the user's location and recenter the map on it. Falls back silently
+// to whatever view the map already has (NYC default) if geolocation is
+// unavailable or denied. `shouldSkip` lets callers bail if the user has already
+// started interacting with the map before the (async) position resolves — we
+// don't want to yank the viewport out from under them.
+export function centerOnUserLocation(
+  map: L.Map,
+  shouldSkip: () => boolean,
+  zoom = 13
+) {
+  if (typeof navigator === "undefined" || !navigator.geolocation) return;
+  navigator.geolocation.getCurrentPosition(
+    (pos) => {
+      if (shouldSkip()) return;
+      map.setView([pos.coords.latitude, pos.coords.longitude], zoom);
+    },
+    () => {
+      // Denied or errored — keep the default view. Nothing to do.
+    },
+    { enableHighAccuracy: false, timeout: 8000, maximumAge: 300000 }
+  );
+}


### PR DESCRIPTION
## What

The maps tab now asks for your location on load and centers on where you are, instead of always opening on Times Square.

## How

- New shared helper `packages/app/src/components/map/geolocate.ts` wraps `navigator.geolocation.getCurrentPosition` (which triggers the browser permission prompt) and recenters the map via `setView`.
- Wired into both `PerformanceMap` and `VenueOnlyMap`.
- **Graceful fallback:** if permission is denied, unavailable, or times out (8s), the map keeps its NYC default — nothing breaks.
- **No viewport yanking:** a `dragstart` guard skips the recenter if the user already started panning before the async position resolved.
- Because the maps already refetch on `moveend` and `setView` fires `moveend`, recentering automatically pulls in showings near the user — no page-level changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)