### PR TITLE
fix: map auto-center locked zoom/pan

### DIFF
--- a/packages/app/src/app/(app)/upcoming/page.tsx
+++ b/packages/app/src/app/(app)/upcoming/page.tsx
@@ -15,6 +15,7 @@ import {
   getDateRange,
   type DateFilter,
 } from "@/lib/mapFilters";
+import { useUserLocation } from "@/components/map/geolocate";
 
 const PerformanceMap = dynamic(
   () => import("@/components/map/PerformanceMap").then((m) => m.PerformanceMap),
@@ -33,6 +34,10 @@ function UpcomingPageContent() {
   const [listExpanded, setListExpanded] = useState(false);
   const [mapBounds, setMapBounds] = useState<{ swLat: number; swLng: number; neLat: number; neLng: number } | null>(null);
   const handleBoundsChange = useCallback((b: typeof mapBounds) => { setMapBounds(b); }, []);
+
+  // Resolved once for the whole page so the VenueOnly → Performance map swap
+  // doesn't re-prompt or fight the user's pan/zoom.
+  const userLocation = useUserLocation();
 
   const dateFilter = (searchParams.get("filter") as DateFilter | null) ?? "all";
   const activeFilter = getActiveFilter(dateFilter);
@@ -127,9 +132,9 @@ function UpcomingPageContent() {
       {view === "map" && (
         <div className="absolute inset-0">
           {hasMapData ? (
-            <PerformanceMap performances={filteredMapPerformances} onBoundsChange={handleBoundsChange} />
+            <PerformanceMap performances={filteredMapPerformances} onBoundsChange={handleBoundsChange} initialCenter={userLocation} />
           ) : (
-            <VenueOnlyMap venues={venues} onBoundsChange={handleBoundsChange} />
+            <VenueOnlyMap venues={venues} onBoundsChange={handleBoundsChange} initialCenter={userLocation} />
           )}
           {/* Subtle refetch indicator — doesn't block the map */}
           {mapFetching && (

--- a/packages/app/src/components/map/PerformanceMap.tsx
+++ b/packages/app/src/components/map/PerformanceMap.tsx
@@ -5,7 +5,7 @@ import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import "leaflet.markercluster";
 import "leaflet.markercluster/dist/MarkerCluster.css";
-import { centerOnUserLocation } from "./geolocate";
+import { NYC_CENTER, DEFAULT_ZOOM, autoCenterOnce } from "./geolocate";
 
 interface Performance {
   id: string;
@@ -40,6 +40,7 @@ interface PerformanceMapProps {
   performances: Performance[];
   className?: string;
   onBoundsChange?: (bounds: MapBounds) => void;
+  initialCenter?: [number, number] | null;
 }
 
 function groupByVenue(performances: Performance[]) {
@@ -126,16 +127,24 @@ function reportBounds(map: L.Map, onBoundsChange: ((b: MapBounds) => void) | und
   });
 }
 
-export function PerformanceMap({ performances, className = "", onBoundsChange }: PerformanceMapProps) {
+export function PerformanceMap({ performances, className = "", onBoundsChange, initialCenter }: PerformanceMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
   const clusterRef = useRef<L.MarkerClusterGroup | null>(null);
   const onBoundsChangeRef = useRef(onBoundsChange);
   onBoundsChangeRef.current = onBoundsChange;
+  // Auto-center guards: skip once the user interacts, and only ever center once.
+  const interactedRef = useRef(false);
+  const centeredRef = useRef(false);
+  const initialCenterRef = useRef(initialCenter);
+  initialCenterRef.current = initialCenter;
 
   useEffect(() => {
     if (!mapRef.current || mapInstanceRef.current) return;
-    const map = L.map(mapRef.current, { zoomControl: false }).setView([40.7580, -73.9855], 13);
+    // If we already know the user's location at mount, open there directly.
+    const start = initialCenterRef.current ?? NYC_CENTER;
+    if (initialCenterRef.current) centeredRef.current = true;
+    const map = L.map(mapRef.current, { zoomControl: false }).setView(start, DEFAULT_ZOOM);
     if (window.matchMedia("(min-width: 768px)").matches) {
       L.control.zoom({ position: "bottomright" }).addTo(map);
     }
@@ -149,14 +158,21 @@ export function PerformanceMap({ performances, className = "", onBoundsChange }:
     reportBounds(map, onBoundsChangeRef.current);
     map.on('moveend', () => reportBounds(map, onBoundsChangeRef.current));
 
-    // Auto-center on the user's location if they grant permission. Skip if
-    // they've already dragged the map by the time the position resolves.
-    let userMoved = false;
-    map.on("dragstart", () => { userMoved = true; });
-    centerOnUserLocation(map, () => userMoved);
+    // Any user-initiated pan or zoom disables auto-centering for good.
+    const markInteracted = () => { interactedRef.current = true; };
+    map.on("dragstart", markInteracted);
+    map.on("zoomstart", markInteracted);
 
     return () => { map.remove(); mapInstanceRef.current = null; };
   }, []);
+
+  // Auto-center when the user's location resolves after mount (once, and only
+  // if they haven't started interacting with the map yet).
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+    autoCenterOnce(map, initialCenter ?? null, interactedRef, centeredRef);
+  }, [initialCenter]);
 
   useEffect(() => {
     const map = mapInstanceRef.current;

--- a/packages/app/src/components/map/VenueOnlyMap.tsx
+++ b/packages/app/src/components/map/VenueOnlyMap.tsx
@@ -5,7 +5,7 @@ import L from "leaflet";
 import "leaflet/dist/leaflet.css";
 import "leaflet.markercluster";
 import "leaflet.markercluster/dist/MarkerCluster.css";
-import { centerOnUserLocation } from "./geolocate";
+import { NYC_CENTER, DEFAULT_ZOOM, autoCenterOnce } from "./geolocate";
 
 interface Venue {
   id: string;
@@ -23,6 +23,7 @@ interface VenueOnlyMapProps {
   venues: Venue[];
   className?: string;
   onBoundsChange?: (bounds: MapBounds) => void;
+  initialCenter?: [number, number] | null;
 }
 
 function reportBounds(map: L.Map, onBoundsChange: ((b: MapBounds) => void) | undefined) {
@@ -38,16 +39,24 @@ function reportBounds(map: L.Map, onBoundsChange: ((b: MapBounds) => void) | und
   });
 }
 
-export function VenueOnlyMap({ venues, className = "", onBoundsChange }: VenueOnlyMapProps) {
+export function VenueOnlyMap({ venues, className = "", onBoundsChange, initialCenter }: VenueOnlyMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<L.Map | null>(null);
   const clusterRef = useRef<L.MarkerClusterGroup | null>(null);
   const onBoundsChangeRef = useRef(onBoundsChange);
   onBoundsChangeRef.current = onBoundsChange;
+  // Auto-center guards: skip once the user interacts, and only ever center once.
+  const interactedRef = useRef(false);
+  const centeredRef = useRef(false);
+  const initialCenterRef = useRef(initialCenter);
+  initialCenterRef.current = initialCenter;
 
   useEffect(() => {
     if (!mapRef.current || mapInstanceRef.current) return;
-    const map = L.map(mapRef.current, { zoomControl: false }).setView([40.7580, -73.9855], 13);
+    // If we already know the user's location at mount, open there directly.
+    const start = initialCenterRef.current ?? NYC_CENTER;
+    if (initialCenterRef.current) centeredRef.current = true;
+    const map = L.map(mapRef.current, { zoomControl: false }).setView(start, DEFAULT_ZOOM);
     if (window.matchMedia("(min-width: 768px)").matches) {
       L.control.zoom({ position: "bottomright" }).addTo(map);
     }
@@ -60,14 +69,21 @@ export function VenueOnlyMap({ venues, className = "", onBoundsChange }: VenueOn
     reportBounds(map, onBoundsChangeRef.current);
     map.on('moveend', () => reportBounds(map, onBoundsChangeRef.current));
 
-    // Auto-center on the user's location if they grant permission. Skip if
-    // they've already dragged the map by the time the position resolves.
-    let userMoved = false;
-    map.on("dragstart", () => { userMoved = true; });
-    centerOnUserLocation(map, () => userMoved);
+    // Any user-initiated pan or zoom disables auto-centering for good.
+    const markInteracted = () => { interactedRef.current = true; };
+    map.on("dragstart", markInteracted);
+    map.on("zoomstart", markInteracted);
 
     return () => { map.remove(); mapInstanceRef.current = null; };
   }, []);
+
+  // Auto-center when the user's location resolves after mount (once, and only
+  // if they haven't started interacting with the map yet).
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+    autoCenterOnce(map, initialCenter ?? null, interactedRef, centeredRef);
+  }, [initialCenter]);
 
   useEffect(() => {
     const map = mapInstanceRef.current;

--- a/packages/app/src/components/map/geolocate.ts
+++ b/packages/app/src/components/map/geolocate.ts
@@ -1,24 +1,42 @@
+import { useEffect, useState } from "react";
 import L from "leaflet";
 
-// Ask for the user's location and recenter the map on it. Falls back silently
-// to whatever view the map already has (NYC default) if geolocation is
-// unavailable or denied. `shouldSkip` lets callers bail if the user has already
-// started interacting with the map before the (async) position resolves — we
-// don't want to yank the viewport out from under them.
-export function centerOnUserLocation(
+// NYC (Times Square) — the default view when geolocation is unavailable/denied.
+export const NYC_CENTER: [number, number] = [40.7580, -73.9855];
+export const DEFAULT_ZOOM = 13;
+
+// Resolve the user's location ONCE per page mount. Returns null until/unless a
+// position is granted. Lives at the page level so the map can swap components
+// (VenueOnlyMap → PerformanceMap) without re-prompting or re-centering.
+export function useUserLocation(): [number, number] | null {
+  const [coords, setCoords] = useState<[number, number] | null>(null);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => setCoords([pos.coords.latitude, pos.coords.longitude]),
+      () => {
+        // Denied or errored — keep the NYC default. Nothing to do.
+      },
+      { enableHighAccuracy: false, timeout: 8000, maximumAge: 300000 }
+    );
+  }, []);
+
+  return coords;
+}
+
+// One-time auto-center for a Leaflet map. Centers on `center` as soon as it's
+// known, but never after the user has started interacting (drag OR zoom) and
+// never more than once. `interactedRef`/`appliedRef` are caller-owned refs so
+// the guard survives re-renders. Returns a cleanup-free no-op; call it from the
+// effect that watches `center`.
+export function autoCenterOnce(
   map: L.Map,
-  shouldSkip: () => boolean,
-  zoom = 13
+  center: [number, number] | null,
+  interactedRef: { current: boolean },
+  appliedRef: { current: boolean }
 ) {
-  if (typeof navigator === "undefined" || !navigator.geolocation) return;
-  navigator.geolocation.getCurrentPosition(
-    (pos) => {
-      if (shouldSkip()) return;
-      map.setView([pos.coords.latitude, pos.coords.longitude], zoom);
-    },
-    () => {
-      // Denied or errored — keep the default view. Nothing to do.
-    },
-    { enableHighAccuracy: false, timeout: 8000, maximumAge: 300000 }
-  );
+  if (!center || appliedRef.current || interactedRef.current) return;
+  appliedRef.current = true;
+  map.setView(center, DEFAULT_ZOOM);
 }


### PR DESCRIPTION
## Problem

After #34 shipped, the maps tab wouldn't let you zoom out or pan to other places.

Two causes:
1. **Zoom wasn't guarded.** Geolocation resolved (near-instantly, from the cache) a beat after you zoomed, and `setView` snapped you back to zoom 13 — felt like the map refused to zoom out.
2. **The `VenueOnlyMap` → `PerformanceMap` swap** (when performance data loads) remounted the map and re-centered, overriding wherever you'd panned.

## Fix

- Location now resolves **once at the page level** via a `useUserLocation()` hook, passed down as an `initialCenter` prop. No per-map geolocation, no re-prompt across the swap.
- Maps open **directly at** `initialCenter` when it's already known at mount (the common case by swap-time), so no NYC flash.
- Auto-center fires **at most once** and is **permanently disabled after any user interaction — drag OR zoom** (`dragstart` + `zoomstart`).
- Falls back to NYC when location is denied/unavailable, same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)