### PR TITLE
fix: map snaps back to origin on zoom-out

### DIFF
--- a/packages/app/src/app/(app)/upcoming/page.tsx
+++ b/packages/app/src/app/(app)/upcoming/page.tsx
@@ -95,7 +95,13 @@ function UpcomingPageContent() {
   }
   const mapPerformances = stableMapPerfsRef.current;
 
-  const hasMapData = mapPerformances.length > 0;
+  // Sticky: once PerformanceMap has shown, never swap back to VenueOnlyMap.
+  // A region with zero performances would otherwise flip this false, unmount
+  // the map, and remount fresh at initialCenter — yanking the user's viewport
+  // back to origin on zoom-out. Empty regions just show no pins instead.
+  const hasEverHadMapDataRef = useRef(false);
+  if (mapPerformances.length > 0) hasEverHadMapDataRef.current = true;
+  const hasMapData = hasEverHadMapDataRef.current;
 
   // Date filtering is now server-side — mapPerformances is already filtered
   const filteredMapPerformances = mapPerformances;


### PR DESCRIPTION
## Problem

Zooming out too far still snapped the map back to the user's location at zoom 13, even after #35.

#35's guard correctly blocks auto-centering *within* a mounted map — but it can't survive a **remount**, and that's what was happening.

## Root cause

In `upcoming/page.tsx`, `hasMapData` is `mapPerformances.length > 0`. Zoom out over a region with no performances in range → the perf query returns zero edges → `hasMapData` flips `false` → the page swaps `PerformanceMap` → `VenueOnlyMap`. That **mounts a fresh map**, which opens at `initialCenter` (your location) at zoom 13 = the snap.

## Fix

`hasMapData` is now **sticky** — once `PerformanceMap` has rendered, we never swap back to `VenueOnlyMap`, so the map never remounts and your pan/zoom is preserved. Empty regions simply show no pins instead of swapping components.

One line of state, no behavior change for the common case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)