### PR TITLE
feat(admin/incoming): incoming-events count in header

### DIFF
--- a/packages/app/src/app/(app)/admin/incoming/page.tsx
+++ b/packages/app/src/app/(app)/admin/incoming/page.tsx
@@ -148,6 +148,9 @@ export default function IncomingEventsPage() {
 
   const items: PendingImportNode[] =
     data?.pendingImports?.edges?.map((e: { node: PendingImportNode }) => e.node) || [];
+  // True count for the active status filter (server-side count, not page-capped).
+  const totalCount: number | null =
+    data?.pendingImports?.totalCount ?? null;
   const pendingItems = items.filter((i) => i.status === "pending");
   const selectableIds = pendingItems.map((i) => i.id);
   const allSelected =
@@ -400,7 +403,14 @@ export default function IncomingEventsPage() {
     <div className="px-6 py-8 max-w-7xl mx-auto space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h1 className="text-xl font-bold text-curtn-cream">Incoming Events</h1>
+          <div className="flex items-center gap-2">
+            <h1 className="text-xl font-bold text-curtn-cream">Incoming Events</h1>
+            {totalCount !== null && (
+              <span className="inline-flex items-center justify-center rounded-full bg-curtn-cream/10 px-2.5 py-0.5 text-sm font-semibold text-curtn-cream tabular-nums">
+                {totalCount}
+              </span>
+            )}
+          </div>
           <p className="mt-1 text-sm text-curtn-muted">
             Review events imported from feeds. Items older than 1 day auto-approve.
           </p>

--- a/packages/app/src/lib/graphql/admin.ts
+++ b/packages/app/src/lib/graphql/admin.ts
@@ -260,6 +260,7 @@ export const PENDING_IMPORTS_QUERY = gql`
           }
         }
       }
+      totalCount
       pageInfo {
         hasNextPage
         endCursor

--- a/packages/server/src/entities/pendingImport/pendingImportTypes.ts
+++ b/packages/server/src/entities/pendingImport/pendingImportTypes.ts
@@ -124,7 +124,15 @@ export const pendingImportType = new GraphQLObjectType({
 })
 
 export const { connectionType: PendingImportConnection, edgeType: PendingImportEdge } = connectionDefinitions({
-  nodeType: pendingImportType
+  nodeType: pendingImportType,
+  connectionFields: {
+    // True count of all matching rows for the active filter (not just the
+    // loaded page). Falls back to edge count if the resolver didn't set it.
+    totalCount: {
+      type: GraphQLInt,
+      resolve: (conn: any) => conn.totalCount ?? conn.edges?.length ?? 0
+    }
+  }
 })
 
 entityRegister({

--- a/packages/server/src/entities/pendingImport/queries/queries.ts
+++ b/packages/server/src/entities/pendingImport/queries/queries.ts
@@ -22,8 +22,11 @@ export const pendingImportQueries = {
       if (args.status) query.status = args.status
       if (args.dataSourceId) query.dataSource = args.dataSourceId
 
-      const items = await PendingImportModel.find(query).sort({ importedAt: -1 }).limit(200).lean()
-      return connectionFromArrayLean(items, args)
+      const [items, totalCount] = await Promise.all([
+        PendingImportModel.find(query).sort({ importedAt: -1 }).limit(200).lean(),
+        PendingImportModel.countDocuments(query)
+      ])
+      return { ...connectionFromArrayLean(items, args), totalCount }
     }
   }
 }


### PR DESCRIPTION
Adds a live count badge next to the **Incoming Events** title showing how many events are in the queue for the active status filter (pending / approved / rejected / flagged).

- Server: new `totalCount` field on the `pendingImports` connection, backed by `countDocuments` for the active filter — accurate beyond the 100/200 page cap.
- App: count badge in the header; updates as you switch status tabs.

Both packages typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)