### PR TITLE
fix(admin/incoming): poster thumbnails collapsing to 0 width

### DIFF
--- a/packages/app/src/app/(app)/admin/incoming/page.tsx
+++ b/packages/app/src/app/(app)/admin/incoming/page.tsx
@@ -691,7 +691,10 @@ function RowGroup(props: {
             <img
               src={item.imageUrl}
               alt=""
-              className="h-12 w-12 object-cover bg-curtn-surface-2"
+              // max-w-none defeats preflight's img{max-width:100%}, which let the
+              // thumbnail shrink to 0 when the w-full auto-layout table ran out of
+              // room and squeezed this column. Keeps the poster a firm 84px.
+              className="h-12 w-12 max-w-none object-cover bg-curtn-surface-2"
             />
           ) : (
             <div className="h-12 w-12 bg-curtn-surface-2 flex items-center justify-center text-curtn-muted/40 text-[10px]">


### PR DESCRIPTION
Posters in the incoming-events table were rendering at width 0 (whole column looked missing). Root cause: the `w-full` auto-layout table squeezes columns under width pressure, and the image — with preflight `img{max-width:100%}` — yielded all the way to 0 (height survived since tables only distribute width).

Fix: `max-w-none` on the thumbnail so its 84px width is firm; the squeeze now falls on the wrappable text columns. Verified live — posters render 84×84, column reopens to 112px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)