### PR TITLE
Browse: dynamic editorial lists, entity following & location-aware featured venues

### DIFF
--- a/packages/app/src/app/(app)/admin/lists/page.tsx
+++ b/packages/app/src/app/(app)/admin/lists/page.tsx
@@ -8,9 +8,11 @@ import {
   LIST_CREATE_MUTATION,
   LIST_SET_EDITORIAL_MUTATION,
   LIST_DELETE_MUTATION,
-  EDITORIAL_LISTS_QUERY,
+  ADMIN_EDITORIAL_LISTS_QUERY,
 } from "@/lib/graphql/lists";
 import { Icon } from "@/components/icons/Icons";
+import { EntitySourcePicker } from "@/components/admin/EntitySourcePicker";
+import { InfiniteList } from "@/components/admin/InfiniteList";
 
 const LIST_TYPES = [
   { value: "shows", label: "Shows" },
@@ -20,35 +22,87 @@ const LIST_TYPES = [
   { value: "people", label: "People" },
 ];
 
+const SOURCE_MODES = [
+  { value: "manual", label: "Manual (hand-picked)" },
+  { value: "entity", label: "Auto — all shows from one entity" },
+  { value: "follows", label: "Auto — shows from entities I follow" },
+];
+
+const ENTITY_TYPES = [
+  { value: "venue", label: "Venue" },
+  { value: "person", label: "Person" },
+  { value: "productionCompany", label: "Production company" },
+];
+
+type SourceEntityType = "venue" | "person" | "productionCompany";
+
+function sourceLabel(list: any): string {
+  if (list.sourceMode === "entity") {
+    return `Auto · ${list.sourceEntityName ?? list.sourceEntityType ?? "entity"}`;
+  }
+  if (list.sourceMode === "follows") {
+    return `Auto · ${list.followTargetType ?? "entities"} I follow`;
+  }
+  return `${list.itemCount} items`;
+}
+
 export default function AdminListsPage() {
   const [name, setName] = useState("");
   const [listType, setListType] = useState("shows");
+  const [sourceMode, setSourceMode] = useState("manual");
+  const [sourceEntityType, setSourceEntityType] = useState<SourceEntityType>("venue");
+  const [selectedEntity, setSelectedEntity] = useState<{ id: string; name: string } | null>(null);
+  const [followTargetType, setFollowTargetType] = useState<SourceEntityType>("person");
   const [error, setError] = useState<string | null>(null);
 
-  const [{ data: editorialData, fetching: editorialFetching }, reexecuteEditorial] = useQuery({
-    query: EDITORIAL_LISTS_QUERY,
-    variables: {},
+  // Active editorial lists (mirrors the browse query). Small, complete, always shown
+  // first in the merged editorial scroll area — never crowded out by the inactive pile.
+  const [{ data: activeData, fetching: activeFetching }, reexecuteActive] = useQuery({
+    query: ADMIN_EDITORIAL_LISTS_QUERY,
+    variables: { activeOnly: true, first: 200 },
   });
 
-  const [{ data: allListsData, fetching: allFetching }, reexecuteAll] = useQuery({
-    query: MY_LISTS_QUERY,
-    variables: { first: 100 },
-  });
+  // Bumped after any mutation to reset the infinite-scroll lists to their first page.
+  const [refreshTick, setRefreshTick] = useState(0);
+  function refreshLists() {
+    reexecuteActive({ requestPolicy: "network-only" });
+    setRefreshTick((t) => t + 1);
+  }
 
   const [, executeCreate] = useMutation(LIST_CREATE_MUTATION);
   const [, executeSetEditorial] = useMutation(LIST_SET_EDITORIAL_MUTATION);
   const [, executeDelete] = useMutation(LIST_DELETE_MUTATION);
 
-  const editorialLists = editorialData?.editorialLists?.edges?.map((e: any) => e.node) ?? [];
-  const allLists = allListsData?.myLists?.edges?.map((e: any) => e.node) ?? [];
+  const activeLists = activeData?.editorialLists?.edges?.map((e: any) => e.node) ?? [];
 
   async function handleQuickCreate() {
     if (!name.trim()) return;
     setError(null);
 
-    const result = await executeCreate({
-      input: { name: name.trim(), listType, isPublic: true },
-    });
+    // Dynamic lists are always lists of shows.
+    const effectiveListType = sourceMode === "manual" ? listType : "shows";
+
+    const input: any = {
+      name: name.trim(),
+      listType: effectiveListType,
+      isPublic: true,
+      sourceMode,
+    };
+
+    if (sourceMode === "entity") {
+      if (!selectedEntity) {
+        setError("Pick an entity to source shows from.");
+        return;
+      }
+      input.sourceEntityType = sourceEntityType;
+      input.sourceEntityId = selectedEntity.id;
+    }
+
+    if (sourceMode === "follows") {
+      input.followTargetType = followTargetType;
+    }
+
+    const result = await executeCreate({ input });
 
     if (result.data?.listCreate?.error) {
       setError(result.data.listCreate.error);
@@ -58,41 +112,120 @@ export default function AdminListsPage() {
     const newList = result.data?.listCreate?.list;
     if (newList) {
       await executeSetEditorial({
-        input: { listId: newList.id, isEditorial: true, isActive: true, displayOrder: editorialLists.length },
+        input: { listId: newList.id, isEditorial: true, isActive: true, displayOrder: activeLists.length },
       });
     }
 
     setName("");
-    reexecuteEditorial({ requestPolicy: "network-only" });
-    reexecuteAll({ requestPolicy: "network-only" });
+    setSelectedEntity(null);
+    setSourceMode("manual");
+    refreshLists();
   }
 
   async function toggleEditorial(listId: string, isCurrentlyEditorial: boolean) {
     await executeSetEditorial({
       input: { listId, isEditorial: !isCurrentlyEditorial },
     });
-    reexecuteEditorial({ requestPolicy: "network-only" });
-    reexecuteAll({ requestPolicy: "network-only" });
+    refreshLists();
   }
 
   async function toggleActive(listId: string, isCurrentlyActive: boolean) {
     await executeSetEditorial({
       input: { listId, isEditorial: true, isActive: !isCurrentlyActive },
     });
-    reexecuteEditorial({ requestPolicy: "network-only" });
+    refreshLists();
   }
 
   async function updateDisplayOrder(listId: string, displayOrder: number) {
     await executeSetEditorial({
       input: { listId, isEditorial: true, displayOrder },
     });
-    reexecuteEditorial({ requestPolicy: "network-only" });
+    refreshLists();
   }
 
   async function handleDelete(listId: string) {
     await executeDelete({ input: { listId } });
-    reexecuteEditorial({ requestPolicy: "network-only" });
-    reexecuteAll({ requestPolicy: "network-only" });
+    refreshLists();
+  }
+
+  function renderEditorialRow(list: any) {
+    return (
+      <div key={list.id} className="flex items-center justify-between border border-curtn-dark/50 bg-curtn-surface px-3 py-2">
+        <div className="flex items-center gap-3">
+          <input
+            type="number"
+            defaultValue={list.displayOrder ?? 0}
+            onBlur={(e) => {
+              const val = parseInt(e.target.value, 10);
+              if (!isNaN(val) && val !== list.displayOrder) {
+                updateDisplayOrder(list.id, val);
+              }
+            }}
+            className="w-12 border border-curtn-dark bg-curtn-deep px-1.5 py-0.5 text-xs text-curtn-cream text-center focus:border-curtn-muted/50 focus:outline-none"
+            title="Display order (lower = first)"
+          />
+          <button
+            type="button"
+            onClick={() => toggleActive(list.id, list.isActive)}
+            className={`text-[10px] uppercase tracking-wider px-1.5 py-0.5 cursor-pointer transition-colors ${
+              list.isActive
+                ? "bg-curtn-acid/20 text-curtn-acid"
+                : "bg-curtn-dark/60 text-curtn-muted/50"
+            }`}
+            title={list.isActive ? "Active — visible on browse" : "Inactive — hidden from browse"}
+          >
+            {list.isActive ? "Active" : "Inactive"}
+          </button>
+          <span className="text-[10px] uppercase tracking-wider text-curtn-muted bg-curtn-dark/60 px-1.5 py-0.5">
+            {list.listType}
+          </span>
+          <Link
+            href={`/u/${list.owner.username}/lists/${list.slug}`}
+            className="text-sm text-curtn-cream hover:text-curtn-coral transition-colors"
+          >
+            {list.name}
+          </Link>
+          <span className="text-[10px] text-curtn-muted/50">{sourceLabel(list)}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => toggleEditorial(list.id, true)}
+            className="text-[10px] text-curtn-muted hover:text-curtn-cream transition-colors cursor-pointer"
+          >
+            Remove from browse
+          </button>
+          <button
+            type="button"
+            onClick={() => handleDelete(list.id)}
+            className="p-1 text-curtn-muted/50 hover:text-curtn-coral transition-colors cursor-pointer"
+          >
+            <Icon name="trash" size={12} />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  function renderYourListRow(list: any) {
+    return (
+      <div key={list.id} className="flex items-center justify-between border border-curtn-dark/30 px-3 py-2">
+        <div className="flex items-center gap-3">
+          <span className="text-[10px] uppercase tracking-wider text-curtn-muted/50 bg-curtn-dark/40 px-1.5 py-0.5">
+            {list.listType}
+          </span>
+          <span className="text-sm text-curtn-muted">{list.name}</span>
+          <span className="text-[10px] text-curtn-muted/50">{list.itemCount} items</span>
+        </div>
+        <button
+          type="button"
+          onClick={() => toggleEditorial(list.id, false)}
+          className="text-[10px] text-curtn-coral hover:text-curtn-red transition-colors cursor-pointer"
+        >
+          Add to browse
+        </button>
+      </div>
+    );
   }
 
   return (
@@ -104,6 +237,7 @@ export default function AdminListsPage() {
       {/* Quick create editorial list */}
       <div className="border border-curtn-dark bg-curtn-surface p-4 space-y-3">
         <p className="text-xs uppercase tracking-widest text-curtn-muted">Create Editorial List</p>
+
         <div className="flex gap-2">
           <input
             type="text"
@@ -113,18 +247,74 @@ export default function AdminListsPage() {
             className="flex-1 border border-curtn-dark bg-curtn-deep px-3 py-1.5 text-sm text-curtn-cream placeholder:text-curtn-muted/40 focus:border-curtn-muted/50 focus:outline-none"
           />
           <select
-            value={listType}
-            onChange={(e) => setListType(e.target.value)}
+            value={sourceMode}
+            onChange={(e) => { setSourceMode(e.target.value); setError(null); }}
             className="border border-curtn-dark bg-curtn-deep px-3 py-1.5 text-sm text-curtn-cream focus:outline-none cursor-pointer"
+            title="How this list is populated"
           >
-            {LIST_TYPES.map((t) => (
-              <option key={t.value} value={t.value}>{t.label}</option>
+            {SOURCE_MODES.map((m) => (
+              <option key={m.value} value={m.value}>{m.label}</option>
             ))}
           </select>
+        </div>
+
+        {/* Mode-specific controls */}
+        {sourceMode === "manual" && (
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] uppercase tracking-wider text-curtn-muted">Item type</span>
+            <select
+              value={listType}
+              onChange={(e) => setListType(e.target.value)}
+              className="border border-curtn-dark bg-curtn-deep px-3 py-1.5 text-sm text-curtn-cream focus:outline-none cursor-pointer"
+            >
+              {LIST_TYPES.map((t) => (
+                <option key={t.value} value={t.value}>{t.label}</option>
+              ))}
+            </select>
+            <span className="text-[10px] text-curtn-muted/50">Add items by hand on the list page.</span>
+          </div>
+        )}
+
+        {sourceMode === "entity" && (
+          <div className="flex items-center gap-2">
+            <select
+              value={sourceEntityType}
+              onChange={(e) => { setSourceEntityType(e.target.value as SourceEntityType); setSelectedEntity(null); }}
+              className="border border-curtn-dark bg-curtn-deep px-3 py-1.5 text-sm text-curtn-cream focus:outline-none cursor-pointer"
+            >
+              {ENTITY_TYPES.map((t) => (
+                <option key={t.value} value={t.value}>{t.label}</option>
+              ))}
+            </select>
+            <EntitySourcePicker
+              entityType={sourceEntityType}
+              value={selectedEntity}
+              onChange={setSelectedEntity}
+            />
+          </div>
+        )}
+
+        {sourceMode === "follows" && (
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] uppercase tracking-wider text-curtn-muted">Shows from</span>
+            <select
+              value={followTargetType}
+              onChange={(e) => setFollowTargetType(e.target.value as SourceEntityType)}
+              className="border border-curtn-dark bg-curtn-deep px-3 py-1.5 text-sm text-curtn-cream focus:outline-none cursor-pointer"
+            >
+              {ENTITY_TYPES.map((t) => (
+                <option key={t.value} value={t.value}>{t.label}s I follow</option>
+              ))}
+            </select>
+            <span className="text-[10px] text-curtn-muted/50">Per-viewer. Hidden when a viewer follows none.</span>
+          </div>
+        )}
+
+        <div className="flex justify-end">
           <button
             type="button"
             onClick={handleQuickCreate}
-            disabled={!name.trim()}
+            disabled={!name.trim() || (sourceMode === "entity" && !selectedEntity)}
             className="bg-curtn-coral px-4 py-1.5 text-xs font-semibold text-curtn-deep uppercase tracking-wider hover:bg-curtn-red disabled:opacity-40 cursor-pointer"
           >
             Create
@@ -133,80 +323,33 @@ export default function AdminListsPage() {
         {error && <p className="text-xs text-curtn-coral">{error}</p>}
       </div>
 
-      {/* Current editorial lists */}
+      {/* Editorial lists — active first, then inactive streams in on scroll */}
       <section>
         <h3 className="text-xs uppercase tracking-widest text-curtn-muted mb-3">
-          Active Editorial Lists ({editorialLists.length})
+          Editorial Lists
+          <span className="ml-2 text-curtn-muted/50 normal-case tracking-normal">
+            {activeLists.length} active on browse
+          </span>
         </h3>
 
-        {editorialFetching ? (
-          <div className="space-y-2">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="h-12 bg-curtn-dark/30 animate-pulse" />
-            ))}
-          </div>
-        ) : editorialLists.length === 0 ? (
-          <p className="text-xs text-curtn-muted/50">No editorial lists yet</p>
-        ) : (
-          <div className="space-y-1">
-            {editorialLists.map((list: any) => (
-              <div key={list.id} className="flex items-center justify-between border border-curtn-dark/50 bg-curtn-surface px-3 py-2">
-                <div className="flex items-center gap-3">
-                  <input
-                    type="number"
-                    defaultValue={list.displayOrder ?? 0}
-                    onBlur={(e) => {
-                      const val = parseInt(e.target.value, 10);
-                      if (!isNaN(val) && val !== list.displayOrder) {
-                        updateDisplayOrder(list.id, val);
-                      }
-                    }}
-                    className="w-12 border border-curtn-dark bg-curtn-deep px-1.5 py-0.5 text-xs text-curtn-cream text-center focus:border-curtn-muted/50 focus:outline-none"
-                    title="Display order (lower = first)"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => toggleActive(list.id, list.isActive)}
-                    className={`text-[10px] uppercase tracking-wider px-1.5 py-0.5 cursor-pointer transition-colors ${
-                      list.isActive
-                        ? "bg-curtn-acid/20 text-curtn-acid"
-                        : "bg-curtn-dark/60 text-curtn-muted/50"
-                    }`}
-                    title={list.isActive ? "Active — visible on browse" : "Inactive — hidden from browse"}
-                  >
-                    {list.isActive ? "Active" : "Inactive"}
-                  </button>
-                  <span className="text-[10px] uppercase tracking-wider text-curtn-muted bg-curtn-dark/60 px-1.5 py-0.5">
-                    {list.listType}
-                  </span>
-                  <Link
-                    href={`/u/${list.owner.username}/lists/${list.slug}`}
-                    className="text-sm text-curtn-cream hover:text-curtn-coral transition-colors"
-                  >
-                    {list.name}
-                  </Link>
-                  <span className="text-[10px] text-curtn-muted/50">{list.itemCount} items</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() => toggleEditorial(list.id, true)}
-                    className="text-[10px] text-curtn-muted hover:text-curtn-cream transition-colors cursor-pointer"
-                  >
-                    Remove from browse
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleDelete(list.id)}
-                    className="p-1 text-curtn-muted/50 hover:text-curtn-coral transition-colors cursor-pointer"
-                  >
-                    <Icon name="trash" size={12} />
-                  </button>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+        <InfiniteList
+          query={ADMIN_EDITORIAL_LISTS_QUERY}
+          connectionKey="editorialLists"
+          variables={{ isActive: false }}
+          renderItem={renderEditorialRow}
+          resetKey={refreshTick}
+          emptyText="No editorial lists yet — create one above."
+          prepend={
+            <>
+              {activeLists.map(renderEditorialRow)}
+              {activeLists.length > 0 && (
+                <p className="pt-3 pb-1 text-[10px] uppercase tracking-wider text-curtn-muted/40">
+                  Inactive
+                </p>
+              )}
+            </>
+          }
+        />
       </section>
 
       {/* All my lists — promote to editorial */}
@@ -215,36 +358,15 @@ export default function AdminListsPage() {
           Your Lists (promote to editorial)
         </h3>
 
-        {allFetching ? (
-          <div className="space-y-2">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="h-10 bg-curtn-dark/30 animate-pulse" />
-            ))}
-          </div>
-        ) : (
-          <div className="space-y-1">
-            {allLists
-              .filter((l: any) => !l.isEditorial)
-              .map((list: any) => (
-                <div key={list.id} className="flex items-center justify-between border border-curtn-dark/30 px-3 py-2">
-                  <div className="flex items-center gap-3">
-                    <span className="text-[10px] uppercase tracking-wider text-curtn-muted/50 bg-curtn-dark/40 px-1.5 py-0.5">
-                      {list.listType}
-                    </span>
-                    <span className="text-sm text-curtn-muted">{list.name}</span>
-                    <span className="text-[10px] text-curtn-muted/50">{list.itemCount} items</span>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => toggleEditorial(list.id, false)}
-                    className="text-[10px] text-curtn-coral hover:text-curtn-red transition-colors cursor-pointer"
-                  >
-                    Add to browse
-                  </button>
-                </div>
-              ))}
-          </div>
-        )}
+        <InfiniteList
+          query={MY_LISTS_QUERY}
+          connectionKey="myLists"
+          variables={{}}
+          filter={(l: any) => !l.isEditorial}
+          renderItem={renderYourListRow}
+          resetKey={refreshTick}
+          emptyText="No non-editorial lists."
+        />
       </section>
     </div>
   );

--- a/packages/app/src/app/(app)/browse/page.tsx
+++ b/packages/app/src/app/(app)/browse/page.tsx
@@ -9,6 +9,7 @@ import { ShowGrid } from "@/components/shows/ShowGrid";
 import { PosterCard } from "@/components/PosterCard";
 import { WiredPosterCard } from "@/components/WiredPosterCard";
 import { Icon } from "@/components/icons/Icons";
+import { useNearbyMetroState } from "@/lib/location/useNearbyMetro";
 
 const PAGE_SIZE = 12;
 const SCROLL_PADDING = 24; // matches px-6
@@ -110,12 +111,33 @@ function BrowseCarousel({ children }: { children: ReactNode }) {
 }
 
 function EditorialCarousel() {
+  // Prompts for location on mount; resolves to the user's nearest metro's state
+  // code (e.g. "NY"), or null while pending / if denied (→ show everything).
+  const metroState = useNearbyMetroState();
+
   const [{ data, fetching }] = useQuery({
     query: EDITORIAL_LISTS_QUERY,
-    variables: { activeOnly: true },
+    variables: { activeOnly: true, first: 200 },
   });
 
-  const lists = data?.editorialLists?.edges?.map((e: any) => e.node) ?? [];
+  const allLists = data?.editorialLists?.edges?.map((e: any) => e.node) ?? [];
+
+  // Resolve a list's item nodes, applying the location filter to venue lists:
+  // when we know the user's metro, only surface featured venues in that state.
+  const itemsForList = (list: any): any[] => {
+    let items = list.items?.edges?.map((e: any) => e.node) ?? [];
+    if (metroState && list.listType === "venues") {
+      items = items.filter((node: any) => node.item?.state === metroState);
+    }
+    return items;
+  };
+
+  // Pair each list with its (possibly filtered) items, then drop any that end up
+  // empty — covers empty manual lists, dynamic lists that resolve to nothing, and
+  // venue lists with no featured venues near the user.
+  const lists = allLists
+    .map((list: any) => ({ list, items: itemsForList(list) }))
+    .filter((entry: { items: any[] }) => entry.items.length > 0);
 
   if (fetching) {
     return (
@@ -138,8 +160,7 @@ function EditorialCarousel() {
 
   return (
     <div className="space-y-10">
-      {lists.map((list: any) => {
-        const items = list.items?.edges?.map((e: any) => e.node) ?? [];
+      {lists.map(({ list, items }: { list: any; items: any[] }) => {
         return (
           <section key={list.id}>
             <div className="flex items-center justify-between mb-4">
@@ -158,15 +179,11 @@ function EditorialCarousel() {
               <p className="text-xs text-curtn-muted mb-3 -mt-2">{list.description}</p>
             )}
 
-            {items.length > 0 ? (
-              <BrowseCarousel>
-                {items.map((item: any) => (
-                  <BrowseItemCard key={item.id} item={item.item} listType={list.listType} />
-                ))}
-              </BrowseCarousel>
-            ) : (
-              <p className="text-xs text-curtn-muted/50">No items in this list yet</p>
-            )}
+            <BrowseCarousel>
+              {items.map((item: any) => (
+                <BrowseItemCard key={item.id} item={item.item} listType={list.listType} />
+              ))}
+            </BrowseCarousel>
           </section>
         );
       })}

--- a/packages/app/src/app/(app)/companies/[slug]/_client.tsx
+++ b/packages/app/src/app/(app)/companies/[slug]/_client.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { COMPANY_BY_SLUG_QUERY } from "@/lib/graphql/companies";
 import { CompanyHero } from "@/components/companies/CompanyHero";
 import { CompanyRuns } from "@/components/companies/CompanyRuns";
+import { EntityFollowButton } from "@/components/follows/EntityFollowButton";
 import { Icon } from "@/components/icons/Icons";
 import { EntityDataSourcesPanel } from "@/components/admin/EntityDataSourcesPanel";
 import { ClaimCTA } from "@/components/claim/ClaimCTA";
@@ -66,6 +67,13 @@ export default function CompanyDetailPage() {
         name={company.name}
         description={company.description}
         logoUrl={company.logoUrl}
+      />
+
+      <EntityFollowButton
+        targetId={company.id}
+        targetType="productionCompany"
+        isFollowedByViewer={company.isFollowedByViewer}
+        size="sm"
       />
 
       <ClaimCTA

--- a/packages/app/src/app/(app)/people/[slug]/_client.tsx
+++ b/packages/app/src/app/(app)/people/[slug]/_client.tsx
@@ -7,6 +7,7 @@ import { PersonHero } from "@/components/people/PersonHero";
 import { PersonCredits } from "@/components/people/PersonCredits";
 import { ClaimPersonButton } from "@/components/people/ClaimPersonButton";
 import { AddToListButton } from "@/components/lists/AddToListButton";
+import { EntityFollowButton } from "@/components/follows/EntityFollowButton";
 import { EditHistory } from "@/components/auditLog/EditHistory";
 import { PendingProposalsStrip } from "@/components/proposals/PendingProposalsStrip";
 import { useAuth } from "@/lib/auth/useAuth";
@@ -64,6 +65,12 @@ export default function PersonDetailPage() {
       />
 
       <div className="flex items-center gap-3">
+        <EntityFollowButton
+          targetId={person.id}
+          targetType="person"
+          isFollowedByViewer={person.isFollowedByViewer}
+          size="sm"
+        />
         <AddToListButton itemId={person.id} listType="people" />
         <ClaimPersonButton
           personId={person.id}

--- a/packages/app/src/app/(app)/venues/[slug]/_client.tsx
+++ b/packages/app/src/app/(app)/venues/[slug]/_client.tsx
@@ -7,6 +7,7 @@ import { VENUE_BY_SLUG_QUERY } from "@/lib/graphql/venues";
 import { VenueHero } from "@/components/venues/VenueHero";
 import { VenuePerformances } from "@/components/venues/VenuePerformances";
 import { AddToListButton } from "@/components/lists/AddToListButton";
+import { EntityFollowButton } from "@/components/follows/EntityFollowButton";
 import { Button } from "@/components/Button";
 import { InlineEditor } from "@/components/admin/InlineEditor";
 import { EntityDataSourcesPanel } from "@/components/admin/EntityDataSourcesPanel";
@@ -85,7 +86,15 @@ export default function VenueDetailPage() {
         isClaimant={!!user && !!venue.claimedBy?.id && decodeId(venue.claimedBy.id) === user.id}
       />
 
-      <AddToListButton itemId={venue.id} listType="venues" />
+      <div className="flex items-center gap-3">
+        <EntityFollowButton
+          targetId={venue.id}
+          targetType="venue"
+          isFollowedByViewer={venue.isFollowedByViewer}
+          size="sm"
+        />
+        <AddToListButton itemId={venue.id} listType="venues" />
+      </div>
 
       {isAdmin && !editing && (
         <Button variant="tertiary" size="sm" icon="pencil" onClick={() => setEditing(true)}>

--- a/packages/app/src/components/admin/EntitySourcePicker.tsx
+++ b/packages/app/src/components/admin/EntitySourcePicker.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "urql";
+import {
+  SEARCH_ALL_VENUES_QUERY,
+  SEARCH_ALL_PEOPLE_QUERY,
+  SEARCH_ALL_COMPANIES_QUERY,
+} from "@/lib/graphql/search";
+
+type SourceEntityType = "venue" | "person" | "productionCompany";
+
+interface SelectedEntity {
+  id: string;
+  name: string;
+}
+
+interface EntitySourcePickerProps {
+  entityType: SourceEntityType;
+  value: SelectedEntity | null;
+  onChange: (entity: SelectedEntity | null) => void;
+}
+
+const CONFIG: Record<SourceEntityType, { query: any; rootField: string; placeholder: string }> = {
+  venue: { query: SEARCH_ALL_VENUES_QUERY, rootField: "venueList", placeholder: "Search venues…" },
+  person: { query: SEARCH_ALL_PEOPLE_QUERY, rootField: "personList", placeholder: "Search people…" },
+  productionCompany: { query: SEARCH_ALL_COMPANIES_QUERY, rootField: "productionCompanyList", placeholder: "Search companies…" },
+};
+
+export function EntitySourcePicker({ entityType, value, onChange }: EntitySourcePickerProps) {
+  const [search, setSearch] = useState("");
+  const config = CONFIG[entityType];
+
+  const [{ data }] = useQuery({
+    query: config.query,
+    variables: { search, first: 8 },
+    pause: search.trim().length < 2,
+  });
+
+  const results: any[] = data?.[config.rootField]?.edges?.map((e: any) => e.node) ?? [];
+
+  if (value) {
+    return (
+      <div className="flex items-center gap-2">
+        <span className="flex-1 border border-curtn-dark bg-curtn-deep px-3 py-1.5 text-sm text-curtn-cream">
+          {value.name}
+        </span>
+        <button
+          type="button"
+          onClick={() => { onChange(null); setSearch(""); }}
+          className="text-[10px] uppercase tracking-wider text-curtn-muted hover:text-curtn-coral cursor-pointer"
+        >
+          Change
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative flex-1">
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder={config.placeholder}
+        className="w-full border border-curtn-dark bg-curtn-deep px-3 py-1.5 text-sm text-curtn-cream placeholder:text-curtn-muted/40 focus:border-curtn-muted/50 focus:outline-none"
+      />
+      {search.trim().length >= 2 && results.length > 0 && (
+        <div className="absolute z-20 mt-1 max-h-56 w-full overflow-y-auto border border-curtn-dark bg-curtn-surface shadow-lg">
+          {results.map((r) => (
+            <button
+              key={r.id}
+              type="button"
+              onClick={() => onChange({ id: r.id, name: r.name })}
+              className="block w-full px-3 py-1.5 text-left text-sm text-curtn-cream hover:bg-curtn-dark/60 cursor-pointer"
+            >
+              {r.name}
+              {r.city && <span className="ml-2 text-[10px] text-curtn-muted/50">{r.city}</span>}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/components/admin/InfiniteList.tsx
+++ b/packages/app/src/components/admin/InfiniteList.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useQuery } from "urql";
+
+interface InfiniteListProps {
+  query: any;
+  /** Root field on the query result holding the Relay connection (e.g. "editorialLists"). */
+  connectionKey: string;
+  /** Base query variables (first/after are managed internally). */
+  variables?: Record<string, any>;
+  pageSize?: number;
+  renderItem: (node: any) => ReactNode;
+  /** Optional client-side filter applied to loaded nodes. */
+  filter?: (node: any) => boolean;
+  /** Rendered inside the scroll area, above the paginated items. */
+  prepend?: ReactNode;
+  /** Change this to reset pagination and refetch from the first page (e.g. after a mutation). */
+  resetKey?: unknown;
+  maxHeight?: string;
+  emptyText?: string;
+}
+
+export function InfiniteList({
+  query,
+  connectionKey,
+  variables = {},
+  pageSize = 20,
+  renderItem,
+  filter,
+  prepend,
+  resetKey,
+  maxHeight = "32rem",
+  emptyText = "Nothing here yet.",
+}: InfiniteListProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const [after, setAfter] = useState<string | null>(null);
+  const [prevEdges, setPrevEdges] = useState<any[]>([]);
+
+  const [result, reexecute] = useQuery({
+    query,
+    variables: { ...variables, first: pageSize, after },
+    requestPolicy: "cache-and-network",
+  });
+
+  const connection = result.data?.[connectionKey];
+  const currentEdges = connection?.edges ?? [];
+  const pageInfo = connection?.pageInfo;
+  const allEdges = after === null ? currentEdges : [...prevEdges, ...currentEdges];
+
+  // Reset to the first page whenever resetKey changes (e.g. after a mutation).
+  useEffect(() => {
+    setPrevEdges([]);
+    setAfter(null);
+    reexecute({ requestPolicy: "network-only" });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resetKey]);
+
+  // Load the next page when the sentinel scrolls into view within the scroll area.
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    const root = scrollRef.current;
+    if (!sentinel || !root) return;
+    if (result.fetching) return;
+    if (!pageInfo?.hasNextPage || !pageInfo.endCursor) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setPrevEdges(allEdges);
+          setAfter(pageInfo.endCursor!);
+        }
+      },
+      { root, rootMargin: "200px" }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [result.fetching, pageInfo?.hasNextPage, pageInfo?.endCursor, allEdges]);
+
+  const nodes = allEdges.map((e: any) => e.node);
+  const visible = filter ? nodes.filter(filter) : nodes;
+  const isEmpty = visible.length === 0 && !prepend && !result.fetching;
+
+  return (
+    <div
+      ref={scrollRef}
+      className="space-y-1 overflow-y-auto pr-1"
+      style={{ maxHeight }}
+    >
+      {prepend}
+      {visible.map(renderItem)}
+
+      {isEmpty && (
+        <p className="text-xs text-curtn-muted/50">{emptyText}</p>
+      )}
+
+      {pageInfo?.hasNextPage && (
+        <div ref={sentinelRef} className="flex justify-center py-3" aria-hidden>
+          {result.fetching && (
+            <div className="h-4 w-4 animate-spin rounded-full border-2 border-curtn-muted/30 border-t-curtn-coral" />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/components/follows/EntityFollowButton.tsx
+++ b/packages/app/src/components/follows/EntityFollowButton.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "urql";
+import { Button } from "@/components/Button";
+import { ENTITY_FOLLOW_TOGGLE_MUTATION } from "@/lib/graphql/follows";
+import { useAuth } from "@/lib/auth/useAuth";
+
+type EntityFollowTargetType = "venue" | "person" | "productionCompany";
+
+interface EntityFollowButtonProps {
+  /** Global (relay) ID of the entity */
+  targetId: string;
+  targetType: EntityFollowTargetType;
+  /** Initial follow state from the entity query */
+  isFollowedByViewer?: boolean;
+  size?: "sm" | "md" | "lg";
+  className?: string;
+}
+
+export function EntityFollowButton({
+  targetId,
+  targetType,
+  isFollowedByViewer,
+  size = "md",
+  className,
+}: EntityFollowButtonProps) {
+  const { user } = useAuth();
+  const [{ fetching }, executeToggle] = useMutation(ENTITY_FOLLOW_TOGGLE_MUTATION);
+  const [optimistic, setOptimistic] = useState<boolean | null>(null);
+
+  // Hide for signed-out viewers (matches user-follow behavior)
+  if (!user) return null;
+
+  const isFollowing = optimistic ?? isFollowedByViewer ?? false;
+
+  async function handleToggle() {
+    const wasFollowing = isFollowing;
+    setOptimistic(!wasFollowing);
+
+    const result = await executeToggle({ input: { targetType, targetId } });
+
+    if (result.error || result.data?.entityFollowToggle?.error) {
+      setOptimistic(wasFollowing);
+    }
+  }
+
+  return (
+    <Button
+      variant={isFollowing ? "secondary" : "primary"}
+      size={size}
+      onClick={handleToggle}
+      disabled={fetching}
+      className={className}
+    >
+      {isFollowing ? "Following" : "Follow"}
+    </Button>
+  );
+}

--- a/packages/app/src/lib/graphql/companies.ts
+++ b/packages/app/src/lib/graphql/companies.ts
@@ -8,6 +8,7 @@ export const COMPANY_BY_SLUG_QUERY = gql`
       slug
       description
       logoUrl
+      isFollowedByViewer
       claimState
       claimedBy {
         id

--- a/packages/app/src/lib/graphql/follows.ts
+++ b/packages/app/src/lib/graphql/follows.ts
@@ -1,8 +1,17 @@
 import { gql } from "urql";
 
 export const FOLLOW_TOGGLE_MUTATION = gql`
-  mutation FollowToggle($input: FollowToggleInput!) {
+  mutation FollowToggle($input: followToggleInput!) {
     followToggle(input: $input) {
+      isFollowing
+      error
+    }
+  }
+`;
+
+export const ENTITY_FOLLOW_TOGGLE_MUTATION = gql`
+  mutation EntityFollowToggle($input: entityFollowToggleInput!) {
+    entityFollowToggle(input: $input) {
       isFollowing
       error
     }

--- a/packages/app/src/lib/graphql/lists.ts
+++ b/packages/app/src/lib/graphql/lists.ts
@@ -12,6 +12,10 @@ export const LIST_FRAGMENT = gql`
     isActive
     displayOrder
     itemCount
+    sourceMode
+    sourceEntityType
+    sourceEntityName
+    followTargetType
     isOwner
     isCollaborator
     owner {
@@ -148,10 +152,31 @@ export const LIST_BY_ID_QUERY = gql`
   ${LIST_FRAGMENT}
 `;
 
-export const EDITORIAL_LISTS_QUERY = gql`
-  query EditorialLists($listType: String, $activeOnly: Boolean) {
-    editorialLists(listType: $listType, activeOnly: $activeOnly) {
+// Lightweight editorial-list query for admin management: list metadata only,
+// no `items` (so dynamic lists don't run their show aggregations just to show a row).
+export const ADMIN_EDITORIAL_LISTS_QUERY = gql`
+  query AdminEditorialLists($activeOnly: Boolean, $isActive: Boolean, $first: Int, $after: String) {
+    editorialLists(activeOnly: $activeOnly, isActive: $isActive, first: $first, after: $after) {
       edges {
+        cursor
+        node {
+          ...ListFields
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+  ${LIST_FRAGMENT}
+`;
+
+export const EDITORIAL_LISTS_QUERY = gql`
+  query EditorialLists($listType: String, $activeOnly: Boolean, $isActive: Boolean, $first: Int, $after: String) {
+    editorialLists(listType: $listType, activeOnly: $activeOnly, isActive: $isActive, first: $first, after: $after) {
+      edges {
+        cursor
         node {
           ...ListFields
           items {
@@ -199,6 +224,10 @@ export const EDITORIAL_LISTS_QUERY = gql`
             }
           }
         }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
       }
     }
   }

--- a/packages/app/src/lib/graphql/people.ts
+++ b/packages/app/src/lib/graphql/people.ts
@@ -9,6 +9,7 @@ export const PERSON_BY_SLUG_QUERY = gql`
       bio
       headshotUrl
       isClaimed
+      isFollowedByViewer
       claimState
       claimedBy {
         id

--- a/packages/app/src/lib/graphql/venues.ts
+++ b/packages/app/src/lib/graphql/venues.ts
@@ -73,6 +73,7 @@ export const VENUE_BY_SLUG_QUERY = gql`
       imageUrl
       permanentlyClosed
       closedDate
+      isFollowedByViewer
       claimState
       claimedBy {
         id

--- a/packages/app/src/lib/location/useNearbyMetro.ts
+++ b/packages/app/src/lib/location/useNearbyMetro.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+
+// Curtn's supported metros. They sit in distinct states, so snapping the user's
+// GPS to the nearest metro is equivalent to picking a state code — which is what
+// we filter venues by (venue.state is a reliable 2-letter code; city strings vary).
+const METROS: Array<{ state: string; lat: number; lng: number }> = [
+  { state: "NY", lat: 40.7128, lng: -74.006 },   // New York City
+  { state: "MN", lat: 44.9778, lng: -93.265 },   // Minneapolis
+  { state: "CA", lat: 34.0522, lng: -118.2437 }, // Los Angeles
+];
+
+// Rough great-circle distance (miles). Precision doesn't matter — we only compare.
+function distanceMiles(aLat: number, aLng: number, bLat: number, bLng: number): number {
+  const R = 3958.8;
+  const dLat = ((bLat - aLat) * Math.PI) / 180;
+  const dLng = ((bLng - aLng) * Math.PI) / 180;
+  const lat1 = (aLat * Math.PI) / 180;
+  const lat2 = (bLat * Math.PI) / 180;
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+/**
+ * Prompts for location once on mount and resolves to the state code of the
+ * user's nearest supported metro (e.g. "NY"). Returns null while pending, or if
+ * the user denies / geolocation is unavailable — callers should treat null as
+ * "no filter, show everything".
+ */
+export function useNearbyMetroState(): string | null {
+  const [metroState, setMetroState] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude, longitude } = pos.coords;
+        let best: string | null = null;
+        let bestDist = Infinity;
+        for (const m of METROS) {
+          const d = distanceMiles(latitude, longitude, m.lat, m.lng);
+          if (d < bestDist) {
+            bestDist = d;
+            best = m.state;
+          }
+        }
+        setMetroState(best);
+      },
+      () => {
+        // Denied or errored — leave null so callers show everything.
+      },
+      { enableHighAccuracy: false, timeout: 8000, maximumAge: 300000 }
+    );
+  }, []);
+
+  return metroState;
+}

--- a/packages/server/src/entities/entityFollow/entityFollowModel.ts
+++ b/packages/server/src/entities/entityFollow/entityFollowModel.ts
@@ -1,0 +1,38 @@
+import mongoose, { Schema, Types } from 'mongoose'
+
+export const ENTITY_FOLLOW_TARGET_TYPES = ['venue', 'person', 'productionCompany'] as const
+export type EntityFollowTargetType = typeof ENTITY_FOLLOW_TARGET_TYPES[number]
+
+export interface IEntityFollow {
+  follower: Types.ObjectId,
+  targetType: EntityFollowTargetType,
+  targetId: Types.ObjectId,
+}
+
+const schema = new Schema<IEntityFollow>({
+  follower: {
+    type: Schema.Types.ObjectId,
+    ref: 'user',
+    required: true
+  },
+  targetType: {
+    type: String,
+    enum: ENTITY_FOLLOW_TARGET_TYPES,
+    required: true
+  },
+  targetId: {
+    type: Schema.Types.ObjectId,
+    required: true
+  }
+}, {
+  timestamps: true
+})
+
+// Prevent duplicate follows of the same entity
+schema.index({ follower: 1, targetType: 1, targetId: 1 }, { unique: true })
+// "what entities of this type does this user follow?" sorted by recency
+schema.index({ follower: 1, targetType: 1, createdAt: -1 })
+// "who follows this entity?"
+schema.index({ targetType: 1, targetId: 1 })
+
+export const EntityFollowModel = (mongoose.models.entityFollow as mongoose.Model<IEntityFollow>) || mongoose.model<IEntityFollow>('entityFollow', schema)

--- a/packages/server/src/entities/entityFollow/isFollowedByViewerField.ts
+++ b/packages/server/src/entities/entityFollow/isFollowedByViewerField.ts
@@ -1,0 +1,22 @@
+import { GraphQLBoolean, GraphQLFieldConfig } from 'graphql'
+import { EntityFollowModel, EntityFollowTargetType } from './entityFollowModel'
+
+/**
+ * Builds an `isFollowedByViewer` GraphQL field for an entity type.
+ * Resolves whether the current viewer follows this entity (via EntityFollow).
+ */
+export function isFollowedByViewerField (targetType: EntityFollowTargetType): GraphQLFieldConfig<any, any> {
+  return {
+    type: GraphQLBoolean,
+    description: 'Whether the current viewer follows this entity',
+    resolve: async (entity: any, _args: any, ctx: any) => {
+      if (!ctx.user) return false
+      const doc = await EntityFollowModel.findOne({
+        follower: ctx.user.id,
+        targetType,
+        targetId: entity._id
+      })
+      return !!doc
+    }
+  }
+}

--- a/packages/server/src/entities/entityFollow/mutations/__tests__/entityFollowToggle.spec.ts
+++ b/packages/server/src/entities/entityFollow/mutations/__tests__/entityFollowToggle.spec.ts
@@ -1,0 +1,93 @@
+import { Types } from 'mongoose'
+import { toGlobalId } from 'graphql-relay'
+import { UserModel } from '../../../user/userModel'
+import { VenueModel } from '../../../venue/venueModel'
+import { PersonModel } from '../../../person/personModel'
+import { ProductionCompanyModel } from '../../../productionCompany/productionCompanyModel'
+import { EntityFollowModel } from '../../entityFollowModel'
+import { entityFollowToggle } from '../entityFollowToggle'
+
+async function callMutation(input: any, ctx: any): Promise<any> {
+  return (entityFollowToggle as any).resolve(null, { input }, ctx, null)
+}
+
+describe('entityFollowToggle', () => {
+  let user: any
+  let venue: any
+  let person: any
+  let company: any
+
+  beforeEach(async () => {
+    await Promise.all([
+      UserModel.deleteMany({}),
+      VenueModel.deleteMany({}),
+      PersonModel.deleteMany({}),
+      ProductionCompanyModel.deleteMany({}),
+      EntityFollowModel.deleteMany({}),
+    ])
+
+    user = await new UserModel({
+      firebaseUid: 'follower-uid', phoneNumber: '+15550000010', username: 'follower',
+    }).save()
+    venue = await new VenueModel({
+      name: 'Caveat', slug: `caveat-${new Types.ObjectId().toString()}`, venueType: 'theater', submittedBy: user._id,
+    }).save()
+    person = await new PersonModel({
+      name: 'Some Actor', slug: `actor-${new Types.ObjectId().toString()}`, submittedBy: user._id,
+    }).save()
+    company = await new ProductionCompanyModel({
+      name: 'A Troupe', slug: `troupe-${new Types.ObjectId().toString()}`, submittedBy: user._id,
+    }).save()
+  })
+
+  it('follows a venue, creating an EntityFollow', async () => {
+    const result = await callMutation(
+      { targetType: 'venue', targetId: toGlobalId('Venue', venue._id.toString()) },
+      { user: { id: user._id.toString() } }
+    )
+    expect(result.error).toBeUndefined()
+    expect(result.isFollowing).toBe(true)
+
+    const doc = await EntityFollowModel.findOne({ follower: user._id, targetType: 'venue', targetId: venue._id })
+    expect(doc).toBeTruthy()
+  })
+
+  it('toggles off on a second call, removing the EntityFollow', async () => {
+    const input = { targetType: 'venue', targetId: toGlobalId('Venue', venue._id.toString()) }
+    const ctx = { user: { id: user._id.toString() } }
+    await callMutation(input, ctx)
+    const result = await callMutation(input, ctx)
+
+    expect(result.isFollowing).toBe(false)
+    const count = await EntityFollowModel.countDocuments({ follower: user._id, targetId: venue._id })
+    expect(count).toBe(0)
+  })
+
+  it('supports following a person and a production company', async () => {
+    const ctx = { user: { id: user._id.toString() } }
+    const p = await callMutation({ targetType: 'person', targetId: toGlobalId('Person', person._id.toString()) }, ctx)
+    const c = await callMutation({ targetType: 'productionCompany', targetId: toGlobalId('ProductionCompany', company._id.toString()) }, ctx)
+
+    expect(p.isFollowing).toBe(true)
+    expect(c.isFollowing).toBe(true)
+    expect(await EntityFollowModel.countDocuments({ follower: user._id })).toBe(2)
+  })
+
+  it('rejects an unauthenticated viewer', async () => {
+    const result = await callMutation(
+      { targetType: 'venue', targetId: toGlobalId('Venue', venue._id.toString()) },
+      {}
+    )
+    expect(result.error).toBe('Unauthorized')
+    expect(result.isFollowing).toBe(false)
+  })
+
+  it('rejects following a nonexistent entity', async () => {
+    const result = await callMutation(
+      { targetType: 'venue', targetId: toGlobalId('Venue', new Types.ObjectId().toString()) },
+      { user: { id: user._id.toString() } }
+    )
+    expect(result.error).toBe('Entity not found')
+    expect(result.isFollowing).toBe(false)
+  })
+})

--- a/packages/server/src/entities/entityFollow/mutations/entityFollow.ts
+++ b/packages/server/src/entities/entityFollow/mutations/entityFollow.ts
@@ -1,0 +1,5 @@
+import { entityFollowToggle } from './entityFollowToggle'
+
+export const entityFollowMutations = {
+  entityFollowToggle
+}

--- a/packages/server/src/entities/entityFollow/mutations/entityFollowToggle.ts
+++ b/packages/server/src/entities/entityFollow/mutations/entityFollowToggle.ts
@@ -1,0 +1,89 @@
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  GraphQLID,
+  GraphQLNonNull
+} from 'graphql'
+import {
+  fromGlobalId,
+  mutationWithClientMutationId
+} from 'graphql-relay'
+import { EntityFollowModel, ENTITY_FOLLOW_TARGET_TYPES, EntityFollowTargetType } from '../entityFollowModel'
+import { errorField } from '../../../graphql/errorField'
+import { VenueModel } from '../../venue/venueModel'
+import { PersonModel } from '../../person/personModel'
+import { ProductionCompanyModel } from '../../productionCompany/productionCompanyModel'
+
+export const entityFollowTargetTypeEnum = new GraphQLEnumType({
+  name: 'EntityFollowTargetType',
+  description: 'Kind of entity that can be followed',
+  values: {
+    venue: { value: 'venue' },
+    person: { value: 'person' },
+    productionCompany: { value: 'productionCompany' }
+  }
+})
+
+const modelFor: Record<EntityFollowTargetType, { exists: (id: string) => Promise<boolean> }> = {
+  venue: { exists: async id => !!(await VenueModel.exists({ _id: id })) },
+  person: { exists: async id => !!(await PersonModel.exists({ _id: id })) },
+  productionCompany: { exists: async id => !!(await ProductionCompanyModel.exists({ _id: id })) }
+}
+
+export const entityFollowToggle = mutationWithClientMutationId({
+  name: 'entityFollowToggle',
+  description: 'Toggle follow/unfollow an entity (venue, person, or production company)',
+  inputFields: {
+    targetType: {
+      type: new GraphQLNonNull(entityFollowTargetTypeEnum),
+      description: 'The kind of entity to follow/unfollow'
+    },
+    targetId: {
+      type: new GraphQLNonNull(GraphQLID),
+      description: 'The global ID of the entity to follow/unfollow'
+    }
+  },
+  outputFields: {
+    isFollowing: {
+      type: GraphQLBoolean,
+      resolve: response => response.isFollowing
+    },
+    ...errorField
+  },
+  mutateAndGetPayload: async ({ targetType, targetId }, ctx) => {
+    if (!ctx.user) {
+      return { isFollowing: false, error: 'Unauthorized' }
+    }
+
+    if (!ENTITY_FOLLOW_TARGET_TYPES.includes(targetType)) {
+      return { isFollowing: false, error: 'Invalid target type' }
+    }
+
+    const { id: decodedId } = fromGlobalId(targetId)
+    const followerId = ctx.user.id
+
+    const exists = await modelFor[targetType as EntityFollowTargetType].exists(decodedId)
+    if (!exists) {
+      return { isFollowing: false, error: 'Entity not found' }
+    }
+
+    const existing = await EntityFollowModel.findOne({
+      follower: followerId,
+      targetType,
+      targetId: decodedId
+    })
+
+    if (existing) {
+      await EntityFollowModel.deleteOne({ _id: existing._id })
+      return { isFollowing: false }
+    }
+
+    await new EntityFollowModel({
+      follower: followerId,
+      targetType,
+      targetId: decodedId
+    }).save()
+
+    return { isFollowing: true }
+  }
+})

--- a/packages/server/src/entities/list/__tests__/dynamicListItems.spec.ts
+++ b/packages/server/src/entities/list/__tests__/dynamicListItems.spec.ts
@@ -1,0 +1,80 @@
+import { Types } from 'mongoose'
+import { UserModel } from '../../user/userModel'
+import { ShowModel } from '../../show/showModel'
+import { VenueModel } from '../../venue/venueModel'
+import { PersonModel } from '../../person/personModel'
+import { RunModel } from '../../run/runModel'
+import { PerformanceModel } from '../../performance/performanceModel'
+import { CreditModel } from '../../credit/creditModel'
+import { EntityFollowModel } from '../../entityFollow/entityFollowModel'
+import { showsForEntities } from '../dynamicListItems'
+import { resolveDynamicListItems } from '../resolveDynamicListItems'
+
+describe('dynamic list items', () => {
+  let user: any
+  let venue: any
+  let person: any
+  let showOld: any
+  let showNew: any
+
+  beforeEach(async () => {
+    await Promise.all([
+      UserModel.deleteMany({}), ShowModel.deleteMany({}), VenueModel.deleteMany({}),
+      PersonModel.deleteMany({}), RunModel.deleteMany({}), PerformanceModel.deleteMany({}),
+      CreditModel.deleteMany({}), EntityFollowModel.deleteMany({}),
+    ])
+
+    user = await new UserModel({ firebaseUid: 'u1', phoneNumber: '+15550001000', username: 'viewer' }).save()
+    venue = await new VenueModel({ name: 'Caveat', slug: `caveat-${new Types.ObjectId()}`, venueType: 'theater', submittedBy: user._id }).save()
+    person = await new PersonModel({ name: 'Actor', slug: `actor-${new Types.ObjectId()}`, submittedBy: user._id }).save()
+    showOld = await new ShowModel({ title: 'Old Show', submittedBy: user._id }).save()
+    showNew = await new ShowModel({ title: 'New Show', submittedBy: user._id }).save()
+
+    // Two runs at the venue, each tied to a show, with performances of different dates
+    const runOld = await new RunModel({ show: showOld._id, venues: [venue._id], submittedBy: user._id }).save()
+    const runNew = await new RunModel({ show: showNew._id, venues: [venue._id], submittedBy: user._id }).save()
+    await new PerformanceModel({ run: runOld._id, venueId: venue._id, date: new Date('2024-01-01'), submittedBy: user._id }).save()
+    await new PerformanceModel({ run: runNew._id, venueId: venue._id, date: new Date('2025-06-01'), submittedBy: user._id }).save()
+
+    // The actor is credited on the newer run only
+    await new CreditModel({ person: person._id, run: runNew._id, creditType: 'cast', role: 'Lead', submittedBy: user._id }).save()
+  })
+
+  it('returns shows at a venue sorted by most recent performance date', async () => {
+    const shows = await showsForEntities('venue', [venue._id])
+    expect(shows.map(s => s.title)).toEqual(['New Show', 'Old Show'])
+    // Each show carries id + _listType for the GraphQL layer
+    expect(shows[0].id).toBe(shows[0]._id.toString())
+    expect(shows[0]._listType).toBe('shows')
+  })
+
+  it('returns shows for a person via their credits', async () => {
+    const shows = await showsForEntities('person', [person._id])
+    expect(shows.map(s => s.title)).toEqual(['New Show'])
+  })
+
+  it('resolves an entity-mode list', async () => {
+    const list = { sourceMode: 'entity', sourceEntityType: 'venue', sourceEntityId: venue._id }
+    const shows = await resolveDynamicListItems(list, { user: { id: user._id.toString() } })
+    expect(shows.map(s => s.title)).toEqual(['New Show', 'Old Show'])
+  })
+
+  it('resolves a follows-mode list from the viewer\'s entity follows', async () => {
+    await new EntityFollowModel({ follower: user._id, targetType: 'venue', targetId: venue._id }).save()
+    const list = { sourceMode: 'follows', followTargetType: 'venue' }
+    const shows = await resolveDynamicListItems(list, { user: { id: user._id.toString() } })
+    expect(shows.map(s => s.title).sort()).toEqual(['New Show', 'Old Show'])
+  })
+
+  it('returns empty for a follows-mode list when the viewer follows nothing', async () => {
+    const list = { sourceMode: 'follows', followTargetType: 'venue' }
+    const shows = await resolveDynamicListItems(list, { user: { id: user._id.toString() } })
+    expect(shows).toEqual([])
+  })
+
+  it('returns empty for a follows-mode list with no viewer', async () => {
+    const list = { sourceMode: 'follows', followTargetType: 'venue' }
+    const shows = await resolveDynamicListItems(list, {})
+    expect(shows).toEqual([])
+  })
+})

--- a/packages/server/src/entities/list/dynamicListItems.ts
+++ b/packages/server/src/entities/list/dynamicListItems.ts
@@ -1,0 +1,106 @@
+import { Types } from 'mongoose'
+import { RunModel } from '../run/runModel'
+import { CreditModel } from '../credit/creditModel'
+import { PerformanceModel } from '../performance/performanceModel'
+import { ShowModel } from '../show/showModel'
+import { ListSourceEntityType } from './listModel'
+
+// Cap how many runs we'll fan out over for a single dynamic list, to bound work
+// for prolific venues/companies. Flagged as a denormalization candidate if it bites.
+const MAX_RUNS = 2000
+// Default number of shows surfaced in a browse carousel.
+export const DEFAULT_DYNAMIC_LIMIT = 24
+
+interface RunRef {
+  _id: Types.ObjectId
+  show?: Types.ObjectId
+  startDate?: Date
+  createdAt?: Date
+}
+
+/**
+ * Resolve the runs relevant to a set of source entities of one type.
+ * Returns lightweight run refs carrying the show id + fallback recency fields.
+ */
+async function runsForEntities (
+  targetType: ListSourceEntityType,
+  targetIds: Types.ObjectId[]
+): Promise<RunRef[]> {
+  if (targetIds.length === 0) return []
+
+  if (targetType === 'venue') {
+    return RunModel.find({ venues: { $in: targetIds } })
+      .select('_id show startDate createdAt')
+      .limit(MAX_RUNS)
+      .lean() as unknown as RunRef[]
+  }
+
+  if (targetType === 'productionCompany') {
+    return RunModel.find({ productionCompany: { $in: targetIds } })
+      .select('_id show startDate createdAt')
+      .limit(MAX_RUNS)
+      .lean() as unknown as RunRef[]
+  }
+
+  // person → credits → runs
+  const runIds = await CreditModel.distinct('run', { person: { $in: targetIds } })
+  if (runIds.length === 0) return []
+  return RunModel.find({ _id: { $in: runIds } })
+    .select('_id show startDate createdAt')
+    .limit(MAX_RUNS)
+    .lean() as unknown as RunRef[]
+}
+
+/**
+ * Returns show documents for the given source entities, sorted by most recent
+ * performance date (descending). Each show carries `id` (so the GraphQL
+ * globalIdField resolves) and `_listType = 'shows'` (so the ListableItem union
+ * resolves its type). Falls back to run start/created date when a run has no
+ * performances yet, so freshly-added shows still appear.
+ */
+export async function showsForEntities (
+  targetType: ListSourceEntityType,
+  targetIds: Types.ObjectId[],
+  limit: number = DEFAULT_DYNAMIC_LIMIT
+): Promise<any[]> {
+  const runs = await runsForEntities(targetType, targetIds)
+  if (runs.length === 0) return []
+
+  const runIds = runs.map(r => r._id)
+
+  // Max performance date per run.
+  const perfAgg: Array<{ _id: Types.ObjectId, lastDate: Date }> = await PerformanceModel.aggregate([
+    { $match: { run: { $in: runIds } } },
+    { $group: { _id: '$run', lastDate: { $max: '$date' } } }
+  ])
+  const perfByRun = new Map<string, Date>()
+  for (const row of perfAgg) perfByRun.set(row._id.toString(), row.lastDate)
+
+  // Fold runs into shows, taking the most recent effective date per show.
+  const showDate = new Map<string, number>()
+  for (const run of runs) {
+    if (!run.show) continue
+    const showId = run.show.toString()
+    const effective = perfByRun.get(run._id.toString()) ?? run.startDate ?? run.createdAt
+    if (!effective) continue
+    const ts = new Date(effective).getTime()
+    const prev = showDate.get(showId)
+    if (prev === undefined || ts > prev) showDate.set(showId, ts)
+  }
+
+  const ordered = [...showDate.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([showId]) => showId)
+
+  if (ordered.length === 0) return []
+
+  const showDocs = await ShowModel.find({ _id: { $in: ordered.map(id => new Types.ObjectId(id)) } }).lean()
+  const byId = new Map<string, any>(showDocs.map(s => [s._id.toString(), s]))
+
+  // Preserve recency order and shape for GraphQL.
+  return ordered
+    .map(id => byId.get(id))
+    .filter(Boolean)
+    .map(show => ({ ...show, id: show._id.toString(), _listType: 'shows' }))
+}

--- a/packages/server/src/entities/list/listModel.ts
+++ b/packages/server/src/entities/list/listModel.ts
@@ -3,6 +3,17 @@ import mongoose, { Schema, Types } from 'mongoose'
 export const LIST_TYPES = ['shows', 'venues', 'runs', 'performances', 'people'] as const
 export type ListType = typeof LIST_TYPES[number]
 
+// How a list's items are populated:
+//  - manual:  hand-picked ListItem docs (the original behavior)
+//  - entity:  auto — all shows from one venue/person/company, by recency
+//  - follows: auto — all shows from the viewer's followed entities of a type, by recency
+export const LIST_SOURCE_MODES = ['manual', 'entity', 'follows'] as const
+export type ListSourceMode = typeof LIST_SOURCE_MODES[number]
+
+// Entity kinds a dynamic list can source shows from (aligns with EntityFollow target types)
+export const LIST_SOURCE_ENTITY_TYPES = ['venue', 'person', 'productionCompany'] as const
+export type ListSourceEntityType = typeof LIST_SOURCE_ENTITY_TYPES[number]
+
 export interface IList {
   name: string
   slug: string
@@ -15,6 +26,10 @@ export interface IList {
   owner: Types.ObjectId
   collaborators: Types.ObjectId[]
   itemCount: number
+  sourceMode: ListSourceMode
+  sourceEntityType?: ListSourceEntityType
+  sourceEntityId?: Types.ObjectId
+  followTargetType?: ListSourceEntityType
   createdAt: Date
   updatedAt: Date
 }
@@ -67,6 +82,25 @@ const listSchema = new Schema<IList>({
   itemCount: {
     type: Number,
     default: 0
+  },
+  sourceMode: {
+    type: String,
+    enum: LIST_SOURCE_MODES,
+    default: 'manual'
+  },
+  sourceEntityType: {
+    type: String,
+    enum: LIST_SOURCE_ENTITY_TYPES,
+    required: false
+  },
+  sourceEntityId: {
+    type: Schema.Types.ObjectId,
+    required: false
+  },
+  followTargetType: {
+    type: String,
+    enum: LIST_SOURCE_ENTITY_TYPES,
+    required: false
   }
 }, {
   timestamps: true

--- a/packages/server/src/entities/list/listTypes.ts
+++ b/packages/server/src/entities/list/listTypes.ts
@@ -42,6 +42,13 @@ const typeNameMap: Record<string, string> = {
   people: 'Person'
 }
 
+// Models for resolving a dynamic list's source entity (keyed by source entity type)
+const sourceEntityModelMap: Record<string, () => any> = {
+  venue: () => require('../venue/venueModel').VenueModel,
+  person: () => require('../person/personModel').PersonModel,
+  productionCompany: () => require('../productionCompany/productionCompanyModel').ProductionCompanyModel
+}
+
 export const ListableItem = new GraphQLUnionType({
   name: 'ListableItem',
   types: () => LIST_TYPES.map(t => typeMap[t]()),
@@ -61,6 +68,8 @@ export const listItemType: GraphQLObjectType = new GraphQLObjectType({
       item: {
         type: ListableItem,
         resolve: async (listItem: any) => {
+          // Dynamic lists synthesize nodes with the item already resolved.
+          if (listItem._resolvedItem) return listItem._resolvedItem
           const list = await ListModel.findById(listItem.list)
           if (!list) return null
           const Model = getModelForListType(list.listType)
@@ -168,11 +177,47 @@ export const listType: GraphQLObjectType = new GraphQLObjectType({
         type: GraphQLInt,
         resolve: (list: any) => list.itemCount
       },
+      sourceMode: {
+        type: GraphQLString,
+        description: 'How items are populated: manual, entity, or follows',
+        resolve: (list: any) => list.sourceMode || 'manual'
+      },
+      sourceEntityType: {
+        type: GraphQLString,
+        description: 'For entity lists: the kind of source entity (venue/person/productionCompany)',
+        resolve: (list: any) => list.sourceEntityType || null
+      },
+      sourceEntityName: {
+        type: GraphQLString,
+        description: 'For entity lists: the display name of the source entity',
+        resolve: async (list: any) => {
+          if (list.sourceMode !== 'entity' || !list.sourceEntityType || !list.sourceEntityId) return null
+          const Model = sourceEntityModelMap[list.sourceEntityType]?.()
+          if (!Model) return null
+          const doc = await Model.findById(list.sourceEntityId).select('name').lean()
+          return doc?.name ?? null
+        }
+      },
+      followTargetType: {
+        type: GraphQLString,
+        description: 'For follows lists: the kind of followed entity (venue/person/productionCompany)',
+        resolve: (list: any) => list.followTargetType || null
+      },
       items: {
         type: ListItemConnection,
         description: 'Items in this list, ordered by position',
         args: { ...connectionArgs },
         resolve: async (list: any, args: any, ctx: any) => {
+          // Dynamic lists (entity / follows) synthesize their items at query time.
+          if (list.sourceMode && list.sourceMode !== 'manual') {
+            const { resolveDynamicListItems } = require('./resolveDynamicListItems')
+            const shows = await resolveDynamicListItems(list, ctx)
+            const edges = shows.map((show: any, i: number) => {
+              const node = { _id: `${list._id}_${show._id}`, position: i, _resolvedItem: show }
+              return { node, cursor: node._id }
+            })
+            return { edges, pageInfo: { hasNextPage: false, hasPreviousPage: false } }
+          }
           // If no pagination args, use DataLoader for batching
           if (!args.first && !args.after && ctx.loaders) {
             const items = await ctx.loaders.listItemsByListLoader.load(list._id.toString())

--- a/packages/server/src/entities/list/mutations/listCreate.ts
+++ b/packages/server/src/entities/list/mutations/listCreate.ts
@@ -1,10 +1,11 @@
 import {
   GraphQLBoolean,
+  GraphQLID,
   GraphQLNonNull,
   GraphQLString
 } from 'graphql'
-import { mutationWithClientMutationId } from 'graphql-relay'
-import { ListModel } from '../listModel'
+import { fromGlobalId, mutationWithClientMutationId } from 'graphql-relay'
+import { ListModel, LIST_SOURCE_ENTITY_TYPES, LIST_SOURCE_MODES } from '../listModel'
 import { listType } from '../listTypes'
 import { errorField } from '../../../graphql/errorField'
 import { generateListSlug } from '../slugify'
@@ -28,6 +29,22 @@ export const listCreate = mutationWithClientMutationId({
     isPublic: {
       type: GraphQLBoolean,
       description: 'Whether the list is public (default true)'
+    },
+    sourceMode: {
+      type: GraphQLString,
+      description: 'How items are populated: manual (default), entity, or follows'
+    },
+    sourceEntityType: {
+      type: GraphQLString,
+      description: 'For entity lists: venue, person, or productionCompany'
+    },
+    sourceEntityId: {
+      type: GraphQLID,
+      description: 'For entity lists: global ID of the source entity'
+    },
+    followTargetType: {
+      type: GraphQLString,
+      description: 'For follows lists: venue, person, or productionCompany'
     }
   },
   outputFields: {
@@ -37,7 +54,7 @@ export const listCreate = mutationWithClientMutationId({
     },
     ...errorField
   },
-  mutateAndGetPayload: async ({ name, description, listType, isPublic }, ctx) => {
+  mutateAndGetPayload: async ({ name, description, listType, isPublic, sourceMode, sourceEntityType, sourceEntityId, followTargetType }, ctx) => {
     if (!ctx.user) {
       return { list: null, error: 'Unauthorized' }
     }
@@ -45,6 +62,36 @@ export const listCreate = mutationWithClientMutationId({
     const validTypes = ['shows', 'venues', 'runs', 'performances', 'people']
     if (!validTypes.includes(listType)) {
       return { list: null, error: `Invalid list type. Must be one of: ${validTypes.join(', ')}` }
+    }
+
+    const mode = sourceMode || 'manual'
+    if (!LIST_SOURCE_MODES.includes(mode)) {
+      return { list: null, error: `Invalid source mode. Must be one of: ${LIST_SOURCE_MODES.join(', ')}` }
+    }
+
+    // Dynamic lists are always lists of shows.
+    if (mode !== 'manual' && listType !== 'shows') {
+      return { list: null, error: 'Dynamic lists (entity/follows) must have listType "shows"' }
+    }
+
+    const extra: any = { sourceMode: mode }
+
+    if (mode === 'entity') {
+      if (!sourceEntityType || !LIST_SOURCE_ENTITY_TYPES.includes(sourceEntityType)) {
+        return { list: null, error: `Entity lists require sourceEntityType: ${LIST_SOURCE_ENTITY_TYPES.join(', ')}` }
+      }
+      if (!sourceEntityId) {
+        return { list: null, error: 'Entity lists require a sourceEntityId' }
+      }
+      extra.sourceEntityType = sourceEntityType
+      extra.sourceEntityId = fromGlobalId(sourceEntityId).id
+    }
+
+    if (mode === 'follows') {
+      if (!followTargetType || !LIST_SOURCE_ENTITY_TYPES.includes(followTargetType)) {
+        return { list: null, error: `Follows lists require followTargetType: ${LIST_SOURCE_ENTITY_TYPES.join(', ')}` }
+      }
+      extra.followTargetType = followTargetType
     }
 
     const slug = await generateListSlug(name, ctx.user.id)
@@ -55,7 +102,8 @@ export const listCreate = mutationWithClientMutationId({
       description: description || '',
       listType,
       isPublic: isPublic !== false,
-      owner: ctx.user.id
+      owner: ctx.user.id,
+      ...extra
     })
 
     return { list }

--- a/packages/server/src/entities/list/queries/editorialLists.ts
+++ b/packages/server/src/entities/list/queries/editorialLists.ts
@@ -15,10 +15,14 @@ export const editorialLists: GraphQLFieldConfig<any, any, any> = {
     activeOnly: {
       type: GraphQLBoolean,
       description: 'If true, only return lists where isActive is true'
+    },
+    isActive: {
+      type: GraphQLBoolean,
+      description: 'If provided, filter by exact active state (true = active, false = inactive)'
     }
   },
   resolve: async (_, args) => {
-    const { listType, activeOnly, ...connArgs } = args
+    const { listType, activeOnly, isActive, ...connArgs } = args
     const filter: any = { isEditorial: true }
 
     if (listType) {
@@ -27,6 +31,8 @@ export const editorialLists: GraphQLFieldConfig<any, any, any> = {
 
     if (activeOnly) {
       filter.isActive = true
+    } else if (typeof isActive === 'boolean') {
+      filter.isActive = isActive
     }
 
     const { filter: cursorFilter, sort, limit } = applyCursorToQuery(filter, {
@@ -34,7 +40,7 @@ export const editorialLists: GraphQLFieldConfig<any, any, any> = {
       first: (connArgs as any).first,
       sortField: 'displayOrder',
       sortDirection: 1,
-      maxLimit: 50
+      maxLimit: 200
     })
     const lists = await ListModel.find(cursorFilter).sort(sort).limit(limit).lean()
     return buildConnection(lists, { first: (connArgs as any).first, sortField: 'displayOrder', maxLimit: 50 })

--- a/packages/server/src/entities/list/resolveDynamicListItems.ts
+++ b/packages/server/src/entities/list/resolveDynamicListItems.ts
@@ -1,0 +1,30 @@
+import { Types } from 'mongoose'
+import { EntityFollowModel } from '../entityFollow/entityFollowModel'
+import { showsForEntities, DEFAULT_DYNAMIC_LIMIT } from './dynamicListItems'
+
+/**
+ * Resolves the show documents for a dynamic list.
+ *  - entity:  shows from the single configured source entity
+ *  - follows: shows from every entity of `followTargetType` the viewer follows
+ * Returns [] when the source is unset or (for follows) the viewer follows nothing,
+ * which causes the list to disappear from the browse page.
+ */
+export async function resolveDynamicListItems (list: any, ctx: any): Promise<any[]> {
+  if (list.sourceMode === 'entity') {
+    if (!list.sourceEntityType || !list.sourceEntityId) return []
+    return showsForEntities(list.sourceEntityType, [list.sourceEntityId], DEFAULT_DYNAMIC_LIMIT)
+  }
+
+  if (list.sourceMode === 'follows') {
+    if (!list.followTargetType || !ctx?.user) return []
+    const follows = await EntityFollowModel.find({
+      follower: ctx.user.id,
+      targetType: list.followTargetType
+    }).select('targetId').lean()
+    const targetIds = follows.map((f: any) => f.targetId as Types.ObjectId)
+    if (targetIds.length === 0) return []
+    return showsForEntities(list.followTargetType, targetIds, DEFAULT_DYNAMIC_LIMIT)
+  }
+
+  return []
+}

--- a/packages/server/src/entities/person/personTypes.ts
+++ b/packages/server/src/entities/person/personTypes.ts
@@ -11,6 +11,7 @@ import { nodeInterface } from '../../graphql/nodeInterface'
 import { globalIdField, connectionDefinitions } from 'graphql-relay'
 import { entityRegister } from '../../graphql/entityHelpers'
 import { claimableFieldsGraphQL } from '../../permissions/claimableFieldsGraphQL'
+import { isFollowedByViewerField } from '../entityFollow/isFollowedByViewerField'
 import { PersonModel } from './personModel'
 import { CreditModel } from '../credit/creditModel'
 import { ShowCreditModel } from '../showCredit/showCreditModel'
@@ -115,6 +116,7 @@ export const personType: GraphQLObjectType = new GraphQLObjectType({
         type: GraphQLString,
         resolve: person => person.updatedAt?.toISOString()
       },
+      isFollowedByViewer: isFollowedByViewerField('person'),
       ...claimableFieldsGraphQL()
     }
   }

--- a/packages/server/src/entities/productionCompany/productionCompanyTypes.ts
+++ b/packages/server/src/entities/productionCompany/productionCompanyTypes.ts
@@ -9,6 +9,7 @@ import { globalIdField, connectionDefinitions, connectionArgs } from 'graphql-re
 import { applyCursorToQuery, buildConnection } from '../../graphql/cursorPagination'
 import { entityRegister } from '../../graphql/entityHelpers'
 import { claimableFieldsGraphQL } from '../../permissions/claimableFieldsGraphQL'
+import { isFollowedByViewerField } from '../entityFollow/isFollowedByViewerField'
 import { ProductionCompanyModel } from './productionCompanyModel'
 import { RunModel } from '../run/runModel'
 import { CreditModel } from '../credit/creditModel'
@@ -97,6 +98,7 @@ export const productionCompanyType: GraphQLObjectType = new GraphQLObjectType({
         type: GraphQLString,
         resolve: company => company.updatedAt?.toISOString()
       },
+      isFollowedByViewer: isFollowedByViewerField('productionCompany'),
       ...claimableFieldsGraphQL()
     }
   }

--- a/packages/server/src/entities/venue/venueTypes.ts
+++ b/packages/server/src/entities/venue/venueTypes.ts
@@ -13,6 +13,7 @@ import {
   import { globalIdField, connectionDefinitions } from 'graphql-relay'
   import { entityRegister } from '../../graphql/entityHelpers'
   import { claimableFieldsGraphQL } from '../../permissions/claimableFieldsGraphQL'
+  import { isFollowedByViewerField } from '../entityFollow/isFollowedByViewerField'
   import { VenueModel } from './venueModel'
   
   // Coordinates type for venue location
@@ -171,6 +172,7 @@ import {
         description: 'When venue was last updated',
         resolve: venue => venue.updatedAt?.toISOString()
       },
+      isFollowedByViewer: isFollowedByViewerField('venue'),
       ...claimableFieldsGraphQL()
     })
   })

--- a/packages/server/src/schemas/mutation.ts
+++ b/packages/server/src/schemas/mutation.ts
@@ -28,6 +28,7 @@ import { removalRequestMutations } from '../entities/removalRequest/mutations/re
 import { proposalMutations } from '../entities/proposal/mutations/proposal'
 import { trustedEditorMutations } from '../entities/trustedEditor/mutations/trustedEditor'
 import { blockMutations } from '../entities/block/mutations/block'
+import { entityFollowMutations } from '../entities/entityFollow/mutations/entityFollow'
 
 export const mutation = new GraphQLObjectType({
   name: 'Mutation',
@@ -58,6 +59,7 @@ export const mutation = new GraphQLObjectType({
     ...removalRequestMutations,
     ...proposalMutations,
     ...trustedEditorMutations,
-    ...blockMutations
+    ...blockMutations,
+    ...entityFollowMutations
   }
 })


### PR DESCRIPTION
## What this ships
Extends the browse page's editorial lists beyond hand-picked items.

**Entity following (new primitive)**
- `EntityFollow` model `{follower, targetType: venue|person|productionCompany, targetId}` — kept separate from user-to-user `Follow` so the activity feed is untouched
- `entityFollowToggle` mutation + `isFollowedByViewer` on the Venue/Person/ProductionCompany types
- Follow buttons on venue, person, and company detail pages

**Dynamic editorial lists**
- `List.sourceMode` (`manual | entity | follows`); dynamic lists synthesize item nodes so the browse page renders them through the existing card path unchanged
- `entity`: all shows from one venue/person/company · `follows`: shows from the viewer's followed entities of a type — both sorted by most-recent performance date
- Empty lists (including follows-lists with no follows) drop off the browse page

**Admin**
- Create form gains a source-mode picker + entity search-select
- Editorial lists merged into one infinite-scroll area (active first); Your Lists too
- Lightweight admin query (no `items`) so dynamic lists don't run aggregations per row

**Location**
- Browse prompts for location and filters featured venue lists to the user's nearest metro (by state); shows all when denied/unavailable

**Fixes**
- Correct GraphQL input type names (`entityFollowToggleInput` / `followToggleInput`) — the latter also fixes the pre-existing user-follow button
- Raise the `editorialLists` page cap so active lists aren't hidden behind inactive ones

## Testing
- 11 new server tests (entity-follow toggle, dynamic list resolver); typecheck clean on both packages
- entityFollowToggle verified end-to-end against the dev DB

## Notes / follow-ups
- Recency falls back to run start/created date when a run has no performances yet
- Dynamic-list fan-out capped at `MAX_RUNS=2000` (denormalization candidate if it bites)
- Location prompt is the native browser one — a styled in-app banner + manual metro override is an easy follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)