### PR TITLE
feat(browse/detail): aspect-ratio posters, two-row shelves, poster/splash cleanup

### DIFF
--- a/packages/app/src/app/(app)/browse/page.tsx
+++ b/packages/app/src/app/(app)/browse/page.tsx
@@ -16,11 +16,33 @@ const SCROLL_PADDING = 24; // matches px-6
 
 type PeekSide = "left" | "right";
 
+// Above this many posters, the shelf stacks into two rows (then scrolls sideways);
+// shorter shelves stay a single row.
+const TWO_ROW_THRESHOLD = 6;
+
+// Source-entity type → detail-page route segment.
+const ENTITY_PATH: Record<string, string> = {
+  venue: "venues",
+  person: "people",
+  productionCompany: "companies",
+};
+
+// "See all" target: entity-sourced lists link to that entity's detail page
+// (e.g. "Shows at Caveat" → the Caveat venue page); others link to the list page.
+function seeAllHref(list: any): string {
+  if (list.sourceMode === "entity" && list.sourceEntityType && list.sourceEntitySlug) {
+    const base = ENTITY_PATH[list.sourceEntityType];
+    if (base) return `/${base}/${list.sourceEntitySlug}`;
+  }
+  return `/u/${list.owner.username}/lists/${list.slug}`;
+}
+
 function BrowseCarousel({ children }: { children: ReactNode }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [peekMap, setPeekMap] = useState<Map<number, PeekSide>>(new Map());
   const childArray = Children.toArray(children);
+  const twoRows = childArray.length > TWO_ROW_THRESHOLD;
 
   const updatePeek = useCallback(() => {
     const container = scrollRef.current;
@@ -67,45 +89,65 @@ function BrowseCarousel({ children }: { children: ReactNode }) {
     container.scrollTo({ left: target, behavior: "smooth" });
   }
 
+  // Each card: uniform height (h-56), width follows the poster's aspect ratio.
+  const renderItem = (child: ReactNode, i: number) => {
+    const side = peekMap.get(i);
+    return (
+      <div
+        key={i}
+        ref={(el) => { itemRefs.current[i] = el; }}
+        className="relative shrink-0 h-full"
+      >
+        {child}
+        {side && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              scrollToItem(i);
+            }}
+            className={`group/peek absolute inset-0 z-10 flex items-center cursor-pointer ${
+              side === "left" ? "justify-end" : "justify-start"
+            }`}
+            aria-label={side === "left" ? "Scroll left" : "Scroll right"}
+          >
+            <div className="absolute inset-0 bg-curtn-deep/40 opacity-0 group-hover/peek:opacity-100 transition-opacity duration-200" />
+            <Icon
+              name={side === "left" ? "caret-left" : "caret-right"}
+              size={24}
+              weight="bold"
+              className="text-curtn-cream opacity-0 group-hover/peek:opacity-100 transition-opacity duration-200 relative mx-2"
+            />
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  // One horizontal scroll container. Few posters → a single flex row. More →
+  // two independent flex rows stacked (each packs its own variable-width cards
+  // tightly, uniform height); w-max lets the rows extend and the container scroll.
   return (
     <div
       ref={scrollRef}
-      className="flex gap-[var(--spacing-2)] overflow-x-auto pb-2 -mx-6 px-6 scrollbar-hide"
+      className="overflow-x-auto pb-2 -mx-6 px-6 scrollbar-hide"
     >
-      {childArray.map((child, i) => {
-        const side = peekMap.get(i);
-        return (
-          <div
-            key={i}
-            ref={(el) => { itemRefs.current[i] = el; }}
-            className="relative shrink-0"
-          >
-            {child}
-            {side && (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  scrollToItem(i);
-                }}
-                className={`group/peek absolute inset-0 z-10 flex items-center cursor-pointer ${
-                  side === "left" ? "justify-end" : "justify-start"
-                }`}
-                aria-label={side === "left" ? "Scroll left" : "Scroll right"}
-              >
-                <div className="absolute inset-0 bg-curtn-deep/40 opacity-0 group-hover/peek:opacity-100 transition-opacity duration-200" />
-                <Icon
-                  name={side === "left" ? "caret-left" : "caret-right"}
-                  size={24}
-                  weight="bold"
-                  className="text-curtn-cream opacity-0 group-hover/peek:opacity-100 transition-opacity duration-200 relative mx-2"
-                />
-              </button>
-            )}
-          </div>
-        );
-      })}
+      {twoRows ? (
+        // Whole shelf = one playbill tall (h-56); the two rows split that height,
+        // so two stacked cards equal a single full-height poster.
+        <div className="flex h-56 w-max flex-col gap-[var(--spacing-2)]">
+          {[0, 1].map((row) => (
+            <div key={row} className="flex min-h-0 flex-1 gap-[var(--spacing-2)]">
+              {childArray.map((child, i) => (i % 2 === row ? renderItem(child, i) : null))}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="flex h-56 gap-[var(--spacing-2)]">
+          {childArray.map((child, i) => renderItem(child, i))}
+        </div>
+      )}
     </div>
   );
 }
@@ -168,7 +210,7 @@ function EditorialCarousel() {
                 {list.name}
               </h3>
               <Link
-                href={`/u/${list.owner.username}/lists/${list.slug}`}
+                href={seeAllHref(list)}
                 className="text-[10px] uppercase tracking-wider text-curtn-muted hover:text-curtn-coral transition-colors"
               >
                 See all
@@ -198,11 +240,11 @@ function BrowseItemCard({ item, listType }: { item: any; listType: string }) {
     return (
       <WiredPosterCard
         showId={item.showId}
-        imageUrl={item.posterUrl || item.imageUrl}
+        imageUrl={item.posterUrl}
         title={item.showTitle}
         href={`/performances/${encodeURIComponent(item.showId)}`}
         size="md"
-        className="!w-36"
+        fitHeight
       />
     );
   }
@@ -215,7 +257,7 @@ function BrowseItemCard({ item, listType }: { item: any; listType: string }) {
         subtitle={`${item.city}, ${item.state}`}
         href={`/venues/${item.venueSlug}`}
         size="lg"
-        className="!w-48"
+        fitHeight
       />
     );
   }
@@ -227,7 +269,7 @@ function BrowseItemCard({ item, listType }: { item: any; listType: string }) {
         title={item.personName}
         href={`/people/${item.personSlug}`}
         size="md"
-        className="!w-32"
+        fitHeight
       />
     );
   }
@@ -237,7 +279,7 @@ function BrowseItemCard({ item, listType }: { item: any; listType: string }) {
     <PosterCard
       title={item.runTitle || item.date || "Item"}
       size="md"
-      className="!w-36"
+      fitHeight
     />
   );
 }

--- a/packages/app/src/app/(app)/performances/[id]/_client.tsx
+++ b/packages/app/src/app/(app)/performances/[id]/_client.tsx
@@ -72,7 +72,7 @@ export default function ShowDetailPage() {
         title: show.title,
         subtitle: sub,
         entityType,
-        posterUrl: show.posterUrl || show.imageUrl,
+        posterUrl: show.posterUrl,
         showId: show.id,
         runId: singleRun?.id || null,
         isOnWatchlist: show.isOnMyWatchlist ?? false,
@@ -250,7 +250,7 @@ export default function ShowDetailPage() {
           intermissions={singleRun.intermissions}
           languages={show.languages}
           imageUrl={show.imageUrl}
-          posterUrl={show.posterUrl}
+          posterUrl={singlePerf.imageUrl || show.posterUrl}
           creators={creators}
           companyName={company?.name}
           companySlug={company?.slug}

--- a/packages/app/src/app/(app)/runs/[id]/_client.tsx
+++ b/packages/app/src/app/(app)/runs/[id]/_client.tsx
@@ -133,7 +133,7 @@ export default function RunDetailPage() {
         title: run.show.title,
         subtitle: sub,
         entityType: forceView === 'run' ? 'Run' : (onlyOnePerf ? 'Performance' : 'Run'),
-        posterUrl: run.posterUrl || run.imageUrl || run.show.posterUrl || run.show.imageUrl,
+        posterUrl: run.posterUrl || run.show.posterUrl,
         showId: run.show.id,
         runId: run.id,
         isOnWatchlist: false,

--- a/packages/app/src/app/(app)/u/[username]/_client.tsx
+++ b/packages/app/src/app/(app)/u/[username]/_client.tsx
@@ -313,7 +313,7 @@ export default function ProfilePage() {
                   <WiredPosterCard
                     key={show.id}
                     showId={show.id}
-                    imageUrl={show.posterUrl || show.imageUrl}
+                    imageUrl={show.posterUrl}
                     title={show.title}
                     href={`/performances/${encodeURIComponent(show.id)}`}
                     size="md"

--- a/packages/app/src/components/DetailHero.tsx
+++ b/packages/app/src/components/DetailHero.tsx
@@ -103,7 +103,7 @@ export function DetailHero({
         <div className="relative -mx-6 -mt-8 mb-6 z-0">
           {/* Backdrop */}
           <div className="relative h-[280px] sm:h-[400px] overflow-hidden">
-            {effectiveImage && effectivePoster ? (
+            {effectiveImage ? (
               <img
                 src={effectiveImage}
                 alt=""
@@ -119,16 +119,21 @@ export function DetailHero({
 
           {/* Poster + title overlay */}
           <div className="relative z-10 -mt-28 sm:-mt-36 px-6 flex flex-col sm:flex-row sm:gap-5 sm:items-end">
-            <div className="w-[140px] shrink-0">
-              <div className="relative aspect-[2/3] rounded-sm border-2 border-curtn-dark/50 bg-curtn-surface shadow-2xl overflow-hidden">
-                <img
-                  src={(effectivePoster || effectiveImage)!}
-                  alt={title}
-                  className="h-full w-full object-cover"
-                  onError={() => setPosterFailed(true)}
-                />
+            {effectivePoster && (
+              <div className="shrink-0">
+                {/* Poster only (never the splash). Uniform height across all detail
+                    pages; width follows the poster's aspect ratio (w-fit avoids
+                    stretching in the column layout). No crop. */}
+                <div className="relative h-[104px] w-fit min-w-[4rem] rounded-sm border-2 border-curtn-dark/50 bg-curtn-surface shadow-2xl overflow-hidden">
+                  <img
+                    src={effectivePoster}
+                    alt={title}
+                    className="block h-full w-auto"
+                    onError={() => setPosterFailed(true)}
+                  />
+                </div>
               </div>
-            </div>
+            )}
             <div className="flex-1 min-w-0 mt-4 sm:mt-0 sm:pb-1">
               {performanceTypes.length > 0 && (
                 <div className="-ml-2.5 mb-2 flex flex-wrap gap-1.5">

--- a/packages/app/src/components/PosterCard.tsx
+++ b/packages/app/src/components/PosterCard.tsx
@@ -117,6 +117,9 @@ interface PosterCardProps {
   /** When true, the card sizes to the image's natural aspect ratio
    *  instead of the default 1/1.58. Used for masonry layouts. */
   naturalAspect?: boolean;
+  /** When true, the card fills its parent's height and its width follows the
+   *  image's aspect ratio (no crop). Used for uniform-height carousel rows. */
+  fitHeight?: boolean;
 }
 
 const sizeClasses = {
@@ -140,6 +143,7 @@ export function PosterCard({
   size = "md",
   className = "",
   naturalAspect = false,
+  fitHeight = false,
 }: PosterCardProps) {
   const [imgFailed, setImgFailed] = useState(false);
   const hasImage = !!imageUrl && !imgFailed;
@@ -151,24 +155,38 @@ export function PosterCard({
   // In natural-aspect mode the image dictates height; fall back to the
   // standard poster ratio when there's no image (TextPoster) or it failed.
   const useNatural = naturalAspect && hasImage;
-  const wrapperAspect = useNatural ? "" : "aspect-[1/1.58]";
+
+  // Layout: fitHeight fills the parent's height and lets width follow the image
+  // (uniform-height carousel rows, no crop). Otherwise use the fixed-width sizing.
+  const outerClass = fitHeight ? "h-full" : sizeClasses[size];
+  const wrapperShape = fitHeight
+    ? hasImage
+      ? "h-full w-auto" // width follows the image (capped on the <img> below)
+      : "h-full aspect-[1/1.58]" // no image → derive width from height
+    : useNatural
+      ? ""
+      : "aspect-[1/1.58]";
+  // fitHeight: fill the row height and let width follow the poster's aspect ratio
+  // (wide stays wide, narrow stays narrow — no crop, no cap). Small min-w just
+  // avoids a zero-width collapse before the image loads.
+  const imgClass = fitHeight
+    ? "h-full w-auto min-w-[4rem] block"
+    : useNatural
+      ? "block w-full h-auto"
+      : "h-full w-full object-cover";
 
   return (
-    <div className={`${sizeClasses[size]} ${className}`}>
+    <div className={`${outerClass} ${className}`}>
       <Wrapper
         {...wrapperProps}
-        className={`group relative block ${wrapperAspect} overflow-hidden bg-curtn-surface border border-curtn-dark/30`}
+        className={`group relative block ${wrapperShape} overflow-hidden bg-curtn-surface border border-curtn-dark/30`}
       >
         {hasImage ? (
           <>
             <img
               src={imageUrl}
               alt={title}
-              className={
-                useNatural
-                  ? "block w-full h-auto"
-                  : "h-full w-full object-cover"
-              }
+              className={imgClass}
               onError={() => setImgFailed(true)}
             />
             {/* Duotone canvas overlay — fades in on hover */}

--- a/packages/app/src/components/WiredPosterCard.tsx
+++ b/packages/app/src/components/WiredPosterCard.tsx
@@ -33,6 +33,8 @@ interface WiredPosterCardProps {
   ticketUrl?: string | null;
   /** When true, the poster sizes to the image's natural aspect ratio. */
   naturalAspect?: boolean;
+  /** When true, the poster fills its parent's height and width follows the image. */
+  fitHeight?: boolean;
 }
 
 export function WiredPosterCard({
@@ -48,6 +50,7 @@ export function WiredPosterCard({
   isOnWatchlist: initialWatchlist = false,
   ticketUrl,
   naturalAspect = false,
+  fitHeight = false,
 }: WiredPosterCardProps) {
   const router = useRouter();
   const { user } = useAuth();
@@ -132,7 +135,7 @@ export function WiredPosterCard({
   ];
 
   return (
-    <div className="relative">
+    <div className={fitHeight ? "relative h-full" : "relative"}>
       <PosterCard
         imageUrl={imageUrl}
         title={title}
@@ -142,6 +145,7 @@ export function WiredPosterCard({
         className={className}
         actions={actions}
         naturalAspect={naturalAspect}
+        fitHeight={fitHeight}
       />
 
       {/* Run picker popup */}

--- a/packages/app/src/components/lists/ListGrid.tsx
+++ b/packages/app/src/components/lists/ListGrid.tsx
@@ -37,7 +37,7 @@ function extractPosterUrls(list: ListNode): string[] {
   return edges.reduce<string[]>((urls, { node }) => {
     const item = node.item;
     if (!item) return urls;
-    const url = item.posterUrl || item.imageUrl || item.venueImageUrl || item.headshotUrl;
+    const url = item.posterUrl || item.venueImageUrl || item.headshotUrl;
     if (url) urls.push(url);
     return urls;
   }, []);

--- a/packages/app/src/components/lists/ListItemRow.tsx
+++ b/packages/app/src/components/lists/ListItemRow.tsx
@@ -33,7 +33,7 @@ function getItemDisplay(item: any) {
       return {
         title: item.showTitle,
         subtitle: item.performanceTypes?.join(", "),
-        image: item.posterUrl || item.imageUrl,
+        image: item.posterUrl,
       };
     case "Venue":
       return {

--- a/packages/app/src/components/reviews/ReviewCard.tsx
+++ b/packages/app/src/components/reviews/ReviewCard.tsx
@@ -48,7 +48,7 @@ export function ReviewCard({ review, showPerformanceLink = false, onDeleted }: R
     : "";
 
   const showTitle = review.run?.show?.title;
-  const showImageUrl = review.run?.show?.posterUrl || review.run?.show?.imageUrl;
+  const showImageUrl = review.run?.show?.posterUrl;
   const runId = review.run?.id;
   const reviewerName = review.user?.fullName || review.user?.username || "Anonymous";
 

--- a/packages/app/src/components/seen/SeenCard.tsx
+++ b/packages/app/src/components/seen/SeenCard.tsx
@@ -47,7 +47,7 @@ export function SeenCard({ seen, showUser = false }: SeenCardProps) {
   if (!run) return null;
 
   const showTitle = run.show.title;
-  const showImageUrl = run.show.posterUrl || run.show.imageUrl;
+  const showImageUrl = run.show.posterUrl;
   const dateRange = formatDateRange(run.startDate, run.endDate);
   const venueName = run.venues?.[0]?.name;
   const userName = seen.user?.fullName || seen.user?.username || "Someone";

--- a/packages/app/src/components/shows/ShowGrid.tsx
+++ b/packages/app/src/components/shows/ShowGrid.tsx
@@ -146,7 +146,7 @@ export function ShowGrid({ shows, loading }: ShowGridProps) {
               <WiredPosterCard
                 key={show.id}
                 showId={show.id}
-                imageUrl={show.posterUrl || show.imageUrl}
+                imageUrl={show.posterUrl}
                 title={show.title}
                 subtitle={firstRun?.productionCompany?.name ?? undefined}
                 href={`/performances/${show.id}`}

--- a/packages/app/src/components/venues/VenuePerformances.tsx
+++ b/packages/app/src/components/venues/VenuePerformances.tsx
@@ -65,7 +65,7 @@ export function VenuePerformances({ venueName }: VenuePerformancesProps) {
             performanceTypes={run.show.performanceTypes}
             companyName={run.productionCompany?.name}
             companySlug={run.productionCompany?.slug}
-            imageUrl={run.show.posterUrl || run.show.imageUrl}
+            imageUrl={run.show.posterUrl}
             startDate={run.startDate}
             endDate={run.endDate}
             averageRating={run.averageRating}

--- a/packages/app/src/lib/graphql/lists.ts
+++ b/packages/app/src/lib/graphql/lists.ts
@@ -15,6 +15,7 @@ export const LIST_FRAGMENT = gql`
     sourceMode
     sourceEntityType
     sourceEntityName
+    sourceEntitySlug
     followTargetType
     isOwner
     isCollaborator

--- a/packages/app/src/lib/graphql/shows.ts
+++ b/packages/app/src/lib/graphql/shows.ts
@@ -186,6 +186,7 @@ export const SINGLE_SHOW_QUERY = gql`
                   id
                   date
                   time
+                  imageUrl
                   venue {
                     id
                     name

--- a/packages/server/src/entities/list/listTypes.ts
+++ b/packages/server/src/entities/list/listTypes.ts
@@ -198,6 +198,17 @@ export const listType: GraphQLObjectType = new GraphQLObjectType({
           return doc?.name ?? null
         }
       },
+      sourceEntitySlug: {
+        type: GraphQLString,
+        description: 'For entity lists: the slug of the source entity (for linking to its detail page)',
+        resolve: async (list: any) => {
+          if (list.sourceMode !== 'entity' || !list.sourceEntityType || !list.sourceEntityId) return null
+          const Model = sourceEntityModelMap[list.sourceEntityType]?.()
+          if (!Model) return null
+          const doc = await Model.findById(list.sourceEntityId).select('slug').lean()
+          return doc?.slug ?? null
+        }
+      },
       followTargetType: {
         type: GraphQLString,
         description: 'For follows lists: the kind of followed entity (venue/person/productionCompany)',

--- a/packages/server/src/scripts/migratePosterImage.ts
+++ b/packages/server/src/scripts/migratePosterImage.ts
@@ -1,0 +1,47 @@
+/**
+ * Migration: for shows/runs that have an image only in `imageUrl` (splash) and no
+ * `posterUrl`, move that image to `posterUrl` and clear `imageUrl`. Rationale: for
+ * ~45% of shows the only image lives in `imageUrl` and functions as the poster, so
+ * once the app treats `imageUrl` strictly as a background splash (never a poster),
+ * those would go blank in previews. Moving it to `posterUrl` makes it the poster
+ * (which is what it is) and leaves splash empty (a splash is optional background).
+ *
+ * Dry-run by default (reports counts). Pass --execute to write.
+ *
+ *   yarn tsnd --transpile-only src/scripts/migratePosterImage.ts            # dry run
+ *   yarn tsnd --transpile-only src/scripts/migratePosterImage.ts --execute  # write
+ */
+import { connectToDatabase, disconnectFromDatabase } from '../db/mongoose'
+import { ShowModel } from '../entities/show/showModel'
+import { RunModel } from '../entities/run/runModel'
+
+const EXECUTE = process.argv.includes('--execute')
+
+// Matches docs with a splash image but no poster.
+const FILTER = { posterUrl: { $in: [null, ''] }, imageUrl: { $nin: [null, ''] } }
+
+// Aggregation-pipeline update: copy imageUrl into posterUrl, then blank imageUrl.
+const UPDATE = [
+  { $set: { posterUrl: '$imageUrl' } },
+  { $set: { imageUrl: '' } }
+]
+
+async function migrateModel (name: string, Model: any) {
+  const count = await Model.countDocuments(FILTER)
+  console.log(`${name}: ${count} document(s) to migrate (imageUrl → posterUrl)`)
+  if (EXECUTE && count > 0) {
+    const res = await Model.updateMany(FILTER, UPDATE)
+    console.log(`  ✓ ${name}: modified ${res.modifiedCount}`)
+  }
+}
+
+async function main () {
+  await connectToDatabase()
+  console.log(EXECUTE ? '=== EXECUTING ===' : '=== DRY RUN (no writes; pass --execute to apply) ===')
+  await migrateModel('Show', ShowModel)
+  await migrateModel('Run', RunModel)
+  console.log('Done.')
+  await disconnectFromDatabase()
+}
+
+main().catch(e => { console.error(e); process.exit(1) })


### PR DESCRIPTION
Brings the one outstanding browse/detail UI commit (`902a4a4`) on this branch into `main`/prod. The scraper engine on this branch is already identical to main; this is purely the browse + detail poster work.

## What's in it
**Browse carousels**
- Poster cards adapt to each poster's aspect ratio at a uniform height (no crop)
- Shelves stack into two rows that scroll horizontally past a threshold; fewer posters stay one row
- Entity-sourced lists' "See all" links to the entity detail page (venue/person/company)

**Detail pages**
- DetailHero poster respects aspect ratio at a fixed height (no crop)
- Splash (`imageUrl`) renders only as the detail backdrop; poster (`posterUrl`) is the foreground + all previews
- Single-performance page honors the per-showing poster override

**Data**
- Added `sourceEntitySlug` to the List type for "See all" routing

## ⚠️ Required prod migration at deploy
`migratePosterImage.ts` moves `imageUrl → posterUrl` for image-only shows/runs (~45% that have only a splash) so they keep an image once splash is background-only. **Must run on prod before/at deploy or those previews go blank.** Already run on dev.

Run with `--execute` (dry-run by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)