### PR TITLE
fix(ingest): scraped images become posters, not splash

### DIFF
--- a/packages/server/src/entities/pendingImport/mutations/reviewPendingImport.ts
+++ b/packages/server/src/entities/pendingImport/mutations/reviewPendingImport.ts
@@ -37,7 +37,12 @@ export async function promoteToRecords(pi: any, userId: string) {
       description: pi.showDescription || '',
       performanceTypes: pi.performanceTypes || [],
       duration: pi.duration || 0,
-      ...(pi.imageUrl && { imageUrl: pi.imageUrl }),
+      // A scraped/OG image is the show's key art — i.e. its poster, not a
+      // background splash. PendingImport has a single image slot, so route it
+      // to posterUrl (imageUrl is now strictly the optional background splash,
+      // which scrapers never provide). See migratePosterImage.ts for the
+      // matching backfill of shows imported before this.
+      ...(pi.imageUrl && { posterUrl: pi.imageUrl }),
       submittedBy: userId,
       source: pi.dataSource
     }).save()

--- a/packages/server/src/services/pendingImport/stage.ts
+++ b/packages/server/src/services/pendingImport/stage.ts
@@ -154,7 +154,10 @@ export async function stageRowsAsPendingImports(
       stageName: head.stageName?.trim() || undefined,
       companyName: head.companyName?.trim() || undefined,
       ticketUrl: head.ticketUrl?.trim() || undefined,
-      imageUrl: head.performanceImageUrl || head.runImageUrl || head.showImageUrl || undefined,
+      // Single image slot; a scraped image is the poster. Prefer an explicit
+      // poster field if a source sets one, else fall back to the image fields.
+      // Approval routes this to show.posterUrl (see reviewPendingImport).
+      imageUrl: head.showPosterUrl || head.runPosterUrl || head.performanceImageUrl || head.runImageUrl || head.showImageUrl || undefined,
       startDate: parseDate(head.runStartDate),
       endDate: parseDate(head.runEndDate),
       cast: cast.length ? cast : undefined,


### PR DESCRIPTION
## Problem
After the splash/poster split (#41), every newly-scraped show rendered with a **blank poster**. The scraper extracts a show's key art into a single image field, but approval routed `PendingImport.imageUrl` → `show.imageUrl` (the background-splash slot), so the poster slot stayed empty.

## Fix
- **`reviewPendingImport`** — on approval, route the single PendingImport image to `posterUrl` (a scraped/OG image is the poster; `imageUrl` is now strictly the optional background splash, which scrapers never provide).
- **`stage.ts`** — staging prefers an explicit poster field if a source sets one, else falls back to the image fields.

Two files, +10/−2.

## Data already imported
Shows imported before this were backfilled with `migratePosterImage.ts --execute` (imageUrl → posterUrl when posterUrl empty): **224 shows migrated, 0 runs**. Still-pending imports (79) will approve straight to `posterUrl` once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)